### PR TITLE
NICTIZ-26187 add pattern to Observation.code in bc-PerinealAssessment

### DIFF
--- a/profiles/bc-PerinealAssessment.xml
+++ b/profiles/bc-PerinealAssessment.xml
@@ -37,6 +37,15 @@
         <comment value="Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)" />
       </mapping>
     </element>
+    <element id="Observation.code">
+      <path value="Observation.code" />
+      <patternCodeableConcept>
+        <coding>
+          <system value="http://snomed.info/sct" />
+          <code value="609625009" />
+        </coding>
+      </patternCodeableConcept>
+    </element>
     <element id="Observation.effective[x]:effectiveDateTime">
       <path value="Observation.effective[x]" />
       <sliceName value="effectiveDateTime" />


### PR DESCRIPTION
NICTIZ-26187 add pattern to Observation.code in bc-PerinealAssessment
Profile that is based on bc-MaternalObservation was missing a Pattern on code, as for example other profiles have (see bc-BarthelIndex, bc-BreastFindings as examples)