### PR TITLE
NICTIZ-33550 add extension bc-bodysite-legalstatusVOTS

### DIFF
--- a/profiles/Extensions/bc-bodysite-legalstatusVOTS.xml
+++ b/profiles/Extensions/bc-bodysite-legalstatusVOTS.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="bc-bodysite-legalstatusVOTS" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/bc-bodysite-legalstatusVOTS" />
+  <version value="1.3.3" />
+  <name value="bc-bodysite-legalstatusVOTS" />
+  <title value="bc-bodysite-legalstatusVOTS" />
+  <status value="active" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="geboortezorg@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Extension on the BodySite resource used to represent whether the (fetus) BodySite has legal status 'Voorlopig Onder Toezichtstelling (VOTS)' or not." />
+  <copyright value="CC0" />
+  <fhirVersion value="3.0.2" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <contextType value="resource" />
+  <context value="BodySite" />
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.extension">
+      <path value="Extension.extension" />
+      <max value="0" />
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-bodysite-legalstatusVOTS" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <type>
+        <code value="boolean" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/profiles/bc-Fetus.xml
+++ b/profiles/bc-Fetus.xml
@@ -62,6 +62,16 @@
         <comment value="Foetus" />
       </mapping>
     </element>
+    <element id="BodySite.extension:LegalstatusVOTS">
+      <path value="BodySite.extension" />
+      <sliceName value="LegalstatusVOTS" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-bodysite-legalstatusVOTS" />
+      </type>
+      <isModifier value="false" />
+    </element>
     <element id="BodySite.extension:child">
       <path value="BodySite.extension" />
       <sliceName value="child" />


### PR DESCRIPTION
NICTIZ-33550 
- add extension bc-bodysite-legalstatusVOTS (modelled on extension bc-familymemberhistory-contributedToDeath, [link](https://simplifier.net/packages/nictiz.fhir.nl.stu3.geboortezorg/1.3.3/files/2935016/~overview) )
- use extension in profile bc-Fetus