### PR TITLE
Created script to generate the -code value sets. Had to fix some inco…

### DIFF
--- a/fhirmapping-3-2.xml
+++ b/fhirmapping-3-2.xml
@@ -796,8 +796,8 @@
 	<record>
 		<ID>peri32-dataelement-10682</ID>
 		<naam>Probleem (OpnameIndicatie_LNR)</naam>
-		<mapping>nvt</mapping>
-		<profile>nvt</profile>
+		<mapping>Condition</mapping>
+		<profile>bc-DisorderOfChild</profile>
 	</record>
 	<record>
 		<ID>peri32-dataelement-10683</ID>
@@ -4819,7 +4819,7 @@
 		<searchurl>GET [base]/Observation?code=http://snomed.info/sct|364336006</searchurl>
 	</record>
 	<record>
-		<ID>peri32-dataelement-4394</ID>
+		<ID>peri32-dataelement-4193</ID>
 		<naam>Werkelijke plaats baring (type locatie) (Observatie)</naam>
 		<mapping>Observation</mapping>
 		<profile>bc-BirthObservation</profile>
@@ -4827,7 +4827,7 @@
 		<searchurl>GET [base]/Observation?code=http://snomed.info/sct|169812000</searchurl>
 	</record>
 	<record>
-		<ID>peri32-dataelement-4395</ID>
+		<ID>peri32-dataelement-1587</ID>
 		<naam>Ziekenhuis baring</naam>
 		<mapping>Observation</mapping>
 		<profile>bc-DeliveryObservation</profile>
@@ -5598,7 +5598,7 @@
 	<record>
 		<ID>peri32-dataelement-2252</ID>
 		<naam>Voorgenomen plaats baring tijdens zwangerschap (Observatie)</naam>
-		<mapping>Observation.value[x]:valueCodeableConcept</mapping>
+		<mapping>Observation</mapping>
 		<profile>bc-MaternalObservation</profile>
 		<in>true</in>
 	</record>
@@ -5712,7 +5712,7 @@
 	<record>
 		<ID>peri32-dataelement-2272</ID>
 		<naam>Voorgenomen achternaam (Observatie)</naam>
-		<mapping>Observation.value[x]:valueString</mapping>
+		<mapping>Observation</mapping>
 		<profile>bc-MaternalObservation</profile>
 		<in>false</in>
 	</record>
@@ -5769,7 +5769,7 @@
 	<record>
 		<ID>peri32-dataelement-2269</ID>
 		<naam>Kraamzorg aangevraagd (Observatie)</naam>
-		<mapping>Observation.value[x]:valueBoolean</mapping>
+		<mapping>Observation</mapping>
 		<profile>bc-MaternalObservation</profile>
 		<in>false</in>
 	</record>
@@ -6726,23 +6726,22 @@
 	<record>
 		<ID>peri32-dataelement-1846</ID>
 		<naam>Maternale sterfte</naam>
-		<mapping>Observation</mapping>
-		<profile>bc-MaternalObservation</profile>
-		<in>VALIDEREN</in>
+		<mapping>Patient</mapping>
+		<profile>nl-core-patient</profile>
 	</record>
 	<record>
 		<ID>peri32-dataelement-1847</ID>
 		<naam>OverlijdensIndicator</naam>
-		<mapping>Observation.value[x]:valueBoolean</mapping>
-		<profile>bc-PregnancyObservation</profile>
+		<mapping>Patient.deceased[x]</mapping>
+		<profile>nl-core-patient</profile>
 		<in>true</in>
 		<zib>peri32-dataelement-686</zib>
 	</record>
 	<record>
 		<ID>peri32-dataelement-1848</ID>
 		<naam>DatumOverlijden</naam>
-		<mapping>Observation.value[x]:valueDateTime</mapping>
-		<profile>bc-PregnancyObservation</profile>
+		<mapping>Patient.deceased[x]</mapping>
+		<profile>nl-core-patient</profile>
 		<in>true</in>
 		<zib>peri32-dataelement-687</zib>
 	</record>
@@ -10070,13 +10069,13 @@
 		<mapping>Practitioner</mapping>
 		<profile>nl-core-practitioner</profile>
 	</record>
-	<record>
+	<!--<record>
 		<ID>peri32-dataelement-1489</ID>
 		<naam>Problematiek kind</naam>
 		<mapping>Condition</mapping>
 		<profile>bc-DisorderOfChild</profile>
 		<in>true</in>
-	</record>
+	</record>-->
 	<record>
 		<ID>peri32-dataelement-1503</ID>
 		<naam>Probleem (ProblematiekKind)</naam>
@@ -10186,13 +10185,13 @@
 		<mapping>Condition.extension:onsetPeriod</mapping>
 		<profile>bc-DisorderOfChild</profile>
 	</record>
-	<record>
+	<!--<record>
 		<ID>peri32-dataelement-1490</ID>
 		<naam>Geboortetrauma</naam>
 		<mapping>Condition</mapping>
 		<profile>bc-DisorderOfChild</profile>
 		<in>true</in>
-	</record>
+	</record>-->
 	<record>
 		<ID>peri32-dataelement-1493</ID>
 		<naam>Probleem (Geboortetrauma)</naam>
@@ -10271,13 +10270,13 @@
 		<in>true</in>
 		<zib>NL-CM-5.1.5</zib>
 	</record>
-	<record>
+	<!--<record>
 		<ID>peri32-dataelement-1513</ID>
 		<naam>Congenitale aandoeningen</naam>
 		<mapping>Condition</mapping>
 		<profile>bc-DisorderOfChild</profile>
 		<in>true</in>
-	</record>
+	</record>-->
 	<record>
 		<ID>peri32-dataelement-1514</ID>
 		<naam>Probleem (Congenitale aandoeningen)</naam>

--- a/profiles/Extensions/bc-bodystructure-child.xml
+++ b/profiles/Extensions/bc-bodystructure-child.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-bodysite-child" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/bc-Child" />

--- a/profiles/Extensions/bc-careplan-contributor.xml
+++ b/profiles/Extensions/bc-careplan-contributor.xml
@@ -32,9 +32,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-careplan-isContributor" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
-      <sliceName value="valueReference" />
       <type>
         <code value="boolean" />
       </type>

--- a/profiles/Extensions/bc-careplan-coordinator.xml
+++ b/profiles/Extensions/bc-careplan-coordinator.xml
@@ -27,15 +27,14 @@
   <differential>
     <element id="Extension.extension">
       <path value="Extension.extension" />
-      <max value="1" />
+      <max value="0" />
     </element>
     <element id="Extension.url">
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-careplan-isCoordinator" />
     </element>
-    <element id="Extension.value[x]:valueBoolean">
+    <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
-      <sliceName value="valueBoolean" />
       <type>
         <code value="boolean" />
       </type>

--- a/profiles/Extensions/bc-childbirthassistance-timecalled.xml
+++ b/profiles/Extensions/bc-childbirthassistance-timecalled.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-childbirthassistance-timecalled" />
     </element>
-    <element id="Extension.value[x]:valueDateTime">
+    <element id="Extension.value[x]">
       <path value="Extension.valueDateTime" />
-      <sliceName value="valueDateTime" />
       <type>
         <code value="dateTime" />
       </type>

--- a/profiles/Extensions/bc-clinicalimpression-procedure.xml
+++ b/profiles/Extensions/bc-clinicalimpression-procedure.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-clinicalimpression-procedure" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure" />

--- a/profiles/Extensions/bc-condition-linesepsis.xml
+++ b/profiles/Extensions/bc-condition-linesepsis.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-condition-linesepsis" />
     </element>
-    <element id="Extension.value[x]:valueBoolean">
+    <element id="Extension.value[x]">
       <path value="Extension.valueBoolean" />
-      <sliceName value="valueBoolean" />
       <type>
         <code value="boolean" />
       </type>

--- a/profiles/Extensions/bc-encounter-arrival.xml
+++ b/profiles/Extensions/bc-encounter-arrival.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-encounter-arrival" />
     </element>
-    <element id="Extension.value[x]:valueCodeableConcept">
+    <element id="Extension.value[x]">
       <path value="Extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/Extensions/bc-encounter-patientparticipant.xml
+++ b/profiles/Extensions/bc-encounter-patientparticipant.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-encounter-patientparticipant" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://fhir.nl/fhir/StructureDefinition/nl-core-patient" />

--- a/profiles/Extensions/bc-encounter-reasonreference.xml
+++ b/profiles/Extensions/bc-encounter-reasonreference.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-encounter-reasonreference" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
       </type>

--- a/profiles/Extensions/bc-episodeofcare-groupidentifier.xml
+++ b/profiles/Extensions/bc-episodeofcare-groupidentifier.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-episodeofcare-groupIdentifier" />
     </element>
-    <element id="Extension.value[x]:valueIdentifier">
+    <element id="Extension.value[x]">
       <path value="Extension.valueIdentifier" />
-      <sliceName value="valueIdentifier" />
       <type>
         <code value="Identifier" />
       </type>

--- a/profiles/Extensions/bc-familymemberhistory-contributedToDeath.xml
+++ b/profiles/Extensions/bc-familymemberhistory-contributedToDeath.xml
@@ -30,9 +30,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-familymemberhistory-contributedToDeath" />
     </element>
-    <element id="Extension.value[x]:valueBoolean">
+    <element id="Extension.value[x]">
       <path value="Extension.valueBoolean" />
-      <sliceName value="valueBoolean" />
       <type>
         <code value="boolean" />
       </type>

--- a/profiles/Extensions/bc-feedingpatterninfant-feedingduration.xml
+++ b/profiles/Extensions/bc-feedingpatterninfant-feedingduration.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-feedingpatterninfant-feedingduration" />
     </element>
-    <element id="Extension.value[x]:valueQuantity">
+    <element id="Extension.value[x]">
       <path value="Extension.valueQuantity" />
-      <sliceName value="valueQuantity" />
       <type>
         <code value="Quantity" />
       </type>

--- a/profiles/Extensions/bc-feedingpatterninfant-feedingquantity.xml
+++ b/profiles/Extensions/bc-feedingpatterninfant-feedingquantity.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-feedingpatterninfant-feedingquantity" />
     </element>
-    <element id="Extension.value[x]:valueQuantity">
+    <element id="Extension.value[x]">
       <path value="Extension.valueQuantity" />
-      <sliceName value="valueQuantity" />
       <type>
         <code value="Quantity" />
       </type>

--- a/profiles/Extensions/bc-goal-careplan.xml
+++ b/profiles/Extensions/bc-goal-careplan.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-careplan-reference" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/CarePlan" />

--- a/profiles/Extensions/bc-observation-laterality.xml
+++ b/profiles/Extensions/bc-observation-laterality.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-observation-laterality" />
     </element>
-    <element id="Extension.value[x]:valueCodeableConcept">
+    <element id="Extension.value[x]">
       <path value="Extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/Extensions/bc-observation-percentile.xml
+++ b/profiles/Extensions/bc-observation-percentile.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-observation-percentile" />
     </element>
-    <element id="Extension.value[x]:valueQuantity">
+    <element id="Extension.value[x]">
       <path value="Extension.valueQuantity" />
-      <sliceName value="valueQuantity" />
       <type>
         <code value="Quantity" />
       </type>

--- a/profiles/Extensions/bc-observation-valuereference.xml
+++ b/profiles/Extensions/bc-observation-valuereference.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-observation-valuereference" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
       </type>

--- a/profiles/Extensions/bc-patient-birthSex.xml
+++ b/profiles/Extensions/bc-patient-birthSex.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-patient-birthSex" />
     </element>
-    <element id="Extension.value[x]:valueCodeableConcept">
+    <element id="Extension.value[x]">
       <path value="Extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/Extensions/bc-patient-ethnicity.xml
+++ b/profiles/Extensions/bc-patient-ethnicity.xml
@@ -35,9 +35,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-patient-ethnicity" />
     </element>
-    <element id="Extension.value[x]:valueCodeableConcept">
+    <element id="Extension.value[x]">
       <path value="Extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/Extensions/bc-procedure-decisionMoment.xml
+++ b/profiles/Extensions/bc-procedure-decisionMoment.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-procedure-decisionMoment" />
     </element>
-    <element id="Extension.value[x]:valueCodeableConcept">
+    <element id="Extension.value[x]">
       <path value="Extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/Extensions/bc-procedure-success.xml
+++ b/profiles/Extensions/bc-procedure-success.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-procedure-success" />
     </element>
-    <element id="Extension.value[x]:valueBoolean">
+    <element id="Extension.value[x]">
       <path value="Extension.valueBoolean" />
-      <sliceName value="valueBoolean" />
       <type>
         <code value="boolean" />
       </type>

--- a/profiles/Extensions/bc-referralrequest-periodOfTransfer.xml
+++ b/profiles/Extensions/bc-referralrequest-periodOfTransfer.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-referralrequest-periodOfTransfer" />
     </element>
-    <element id="Extension.value[x]:valueCodeableConcept">
+    <element id="Extension.value[x]">
       <path value="Extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/Extensions/bc-referralrequest-reasonReference.xml
+++ b/profiles/Extensions/bc-referralrequest-reasonReference.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-referralrequest-reasonReference" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
       </type>

--- a/profiles/Extensions/bc-referralrequest-requesterSpeciality.xml
+++ b/profiles/Extensions/bc-referralrequest-requesterSpeciality.xml
@@ -34,9 +34,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-referralrequest-requesterSpecialty" />
     </element>
-    <element id="Extension.value[x]:valueCodeableConcept">
+    <element id="Extension.value[x]">
       <path value="Extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/Extensions/bc-riskassessment-focus.xml
+++ b/profiles/Extensions/bc-riskassessment-focus.xml
@@ -30,9 +30,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/riskassessment-focus" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <short value="focus" />
       <definition value="The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record. The focus of an observation could also be an existing condition, an intervention, the subject's diet, another observation of the subject, or a body structure such as tumor or implanted device. An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus." />
       <comment value="Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., &quot;Blood Glucose&quot;) and does not need to be represented separately using this element. Use specimen if a reference to a specimen is required. If a code is required instead of a resource use either bodysite for bodysites or the standard extension focusCode." />

--- a/profiles/Extensions/bc-treatmentdirective-endreason.xml
+++ b/profiles/Extensions/bc-treatmentdirective-endreason.xml
@@ -29,9 +29,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-treatmentdirective-endreason" />
     </element>
-    <element id="Extension.value[x]:valueString">
-      <path value="Extension.valueString" />
-      <sliceName value="valueString" />
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
       <type>
         <code value="string" />
       </type>

--- a/profiles/Extensions/ext-TreatmentDirective2.AdvanceDirective.xml
+++ b/profiles/Extensions/ext-TreatmentDirective2.AdvanceDirective.xml
@@ -39,9 +39,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-treatmentdirective-advancedirective" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
-      <sliceName value="valueReference" />
       <short value="AdvanceDirective" />
       <definition value="A (written) statement in which a person indicates wishes concerning future medical action, in the event that this person is at that point no longer (deemed) capable of taking decisions on the matter." />
       <alias value="Wilsverklaring" />

--- a/profiles/Extensions/ext-TreatmentDirective2.ReasonForEnding.xml
+++ b/profiles/Extensions/ext-TreatmentDirective2.ReasonForEnding.xml
@@ -39,9 +39,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-treatmentdirective-reasonforending" />
     </element>
-    <element id="Extension.value[x]:valueString">
+    <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
-      <sliceName value="valueString" />
       <short value="ReasonForEnding" />
       <definition value="Reason why the agreement on a treatment directive no longer applies." />
       <alias value="RedenBeeindigd" />

--- a/profiles/Extensions/ext-TreatmentDirective2.SpecificationOther.xml
+++ b/profiles/Extensions/ext-TreatmentDirective2.SpecificationOther.xml
@@ -40,9 +40,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/bc-treatmentdirective-specificationother" />
     </element>
-    <element id="Extension.value[x]:valueString">
+    <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
-      <sliceName value="valueString" />
       <short value="SpecificationOther" />
       <definition value="Specification of the treatment decision when the decision is 'Other'." />
       <alias value="SpecificatieAnders" />

--- a/profiles/Extensions/observation-component-valueBooleanSTU3.xml
+++ b/profiles/Extensions/observation-component-valueBooleanSTU3.xml
@@ -30,9 +30,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/observation-component-valueBooleanSTU3" />
     </element>
-    <element id="Extension.value[x]:valueBoolean">
+    <element id="Extension.value[x]">
       <path value="Extension.valueBoolean" />
-      <sliceName value="valueBoolean" />
       <short value="supportingInfo" />
       <definition value="Other resources *from the patient record* that may be relevant to the event. The information from these resources was either used to create the instance or is provided to help with its interpretation. This extension **should not** be used if more specific inline elements or extensions are available. For example, use `Observation.hasMember` instead of supportingInformation for representing the members of an Observation panel." />
       <type>

--- a/profiles/Extensions/valueset-concept-comments.xml
+++ b/profiles/Extensions/valueset-concept-comments.xml
@@ -38,9 +38,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/valueset-concept-comments" />
     </element>
-    <element id="Extension.value[x]:valueString">
+    <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
-      <sliceName value="valueString" />
       <min value="1" />
       <type>
         <code value="string" />

--- a/profiles/Extensions/valueset-deprecated.xml
+++ b/profiles/Extensions/valueset-deprecated.xml
@@ -39,9 +39,8 @@
             <path value="Extension.url"/>
             <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/valueset-deprecated"/>
         </element>
-        <element id="Extension.value[x]:valueBoolean">
+        <element id="Extension.value[x]">
             <path value="Extension.value[x]"/>
-            <sliceName value="valueBoolean" />
             <min value="1"/>
             <type>
                 <code value="boolean"/>

--- a/profiles/Extensions/workflow-supportingInfoSTU3.xml
+++ b/profiles/Extensions/workflow-supportingInfoSTU3.xml
@@ -32,9 +32,8 @@
       <path value="Extension.url" />
       <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/workflow-supportingInfoSTU3" />
     </element>
-    <element id="Extension.value[x]:valueReference">
+    <element id="Extension.value[x]">
       <path value="Extension.valueReference" />
-      <sliceName value="valueReference" />
       <short value="supportingInfo" />
       <definition value="Other resources *from the patient record* that may be relevant to the event. The information from these resources was either used to create the instance or is provided to help with its interpretation. This extension **should not** be used if more specific inline elements or extensions are available. For example, use `Observation.hasMember` instead of supportingInformation for representing the members of an Observation panel." />
       <type>

--- a/profiles/ValueSets/VerrichtingType_kraambed-2.16.840.1.113883.2.4.11.312--20210208151257.xml
+++ b/profiles/ValueSets/VerrichtingType_kraambed-2.16.840.1.113883.2.4.11.312--20210208151257.xml
@@ -1,0 +1,82 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="2.16.840.1.113883.2.4.11.312--20210208151257"/>
+    <meta>
+        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/3.0/StructureDefinition/ValueSet"/>-->
+    </meta>
+    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+        <valuePeriod>
+            <start value="2021-02-08T15:12:57Z"/>
+        </valuePeriod>
+    </extension>
+    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.312--20210208151257"/>
+    <identifier>
+        <use value="official"/>
+        <system value="urn:ietf:rfc:3986"/>
+        <value value="urn:oid:2.16.840.1.113883.2.4.11.312"/>
+    </identifier>
+    <version value="2021-02-08T15:12:57"/>
+    <name value="VerrichtingType_kraambed"/>
+    <title value="VerrichtingType_kraambed"/>
+    <status value="draft"/>
+    <experimental value="false"/>
+    <publisher value="Nictiz"/>
+    <contact>
+        <name value="Nictiz"/>
+        <telecom>
+            <system value="phone"/>
+            <value value="070-3173450"/>
+        </telecom>
+    </contact>
+    <description value="VerrichtingType_kraambed"/>
+    <immutable value="false"/>
+    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+    <compose>
+        <include>
+            <system value="http://snomed.info/sct"/>
+            <concept>
+                <code value="133906008"/>
+                <display value="postnatale zorg (regime/therapie)"/>
+            </concept>
+            <concept>
+                <code value="408883002"/>
+                <display value="borstvoedingsondersteuning (regime/therapie)"/>
+            </concept>
+            <concept>
+                <code value="385942004"/>
+                <display value="wondzorg (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="409073007"/>
+                <display value="voorlichting (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="710716009"/>
+                <display value="voorlichten over verzorging van borsten tijdens postpartumperiode (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="243097005"/>
+                <display value="voorlichten over perineale hygiëne (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="75461000"/>
+                <display value="voorlichten over verzorgen van zuigeling (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="171053005"/>
+                <display value="voorlichten over voeden van zuigeling (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="243094003"/>
+                <display value="voorlichten over borstvoeding (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="243096001"/>
+                <display value="voorlichten over correct aanleggen van baby aan borst (verrichting)"/>
+            </concept>
+            <concept>
+                <code value="430252009"/>
+                <display value="voorlichten over stimuleren van ontwikkeling van zuigeling van 0-4 maanden (verrichting)"/>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/profiles/ValueSets/bc-BirthObservation-code.xml
+++ b/profiles/ValueSets/bc-BirthObservation-code.xml
@@ -1,54 +1,62 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
-   <id value="bc-BirthObservation-code" />
+   <id value="bc-BirthObservation-code"/>
    <meta>
-      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset" />
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
    </meta>
-   <url value="http://nictiz.nl/fhir/ValueSet/bc-BirthObservation-code" />
-   <version value="1.3.3" />
-   <name value="bc-BirthObservation-code" />
-   <title value="bc-BirthObservation-code" />
-   <status value="draft" />
-   <experimental value="false" />
-   <publisher value="Nictiz" />
-   <description value="bc-BirthObservation-code" />
-   <immutable value="false" />
-   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org." />
+   <url value="http://nictiz.nl/fhir/ValueSet/bc-BirthObservation-code"/>
+   <version value="1.3.3"/>
+   <name value="bc-BirthObservation-code"/>
+   <title value="bc-BirthObservation-code"/>
+   <status value="draft"/>
+   <experimental value="false"/>
+   <publisher value="Nictiz"/>
+   <description value="bc-BirthObservation-code"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
    <compose>
       <include>
-         <system value="http://snomed.info/sct" />
+         <system value="http://snomed.info/sct"/>
          <concept>
-            <code value="289251005" />
-            <display
-               value="tijdstip waarop gebroken vliezen zijn geconstateerd (waarneembare entiteit)" />
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4196 WerkelijkePlaatsBaringWaarde"/>
+            </extension>
+            <code value="366344009"/>
+            <display value="bevinding betreffende locatie van partus"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4135 ActiefMeepersenWaarde"/>
+            </extension>
             <code value="249163006"/>
             <display value="begin van persen tijdens partus (waarneembare entiteit)"/>
          </concept>
-          <concept>
-            <code value="364336006" />
-            <display value="soort partus (waarneembare entiteit)" />
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10247 DuurUitdrijvingWaarde"/>
+            </extension>
+            <code value="169822006"/>
+            <display value="duur van tweede fase van partus (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="249163006" />
-            <display value="begin van persen tijdens partus (waarneembare entiteit)" />
-         </concept>
-         <concept>
-            <code value="366344009"/>
-            <display value="bevinding betreffende locatie van partus (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="386639001"/>
-            <display value="afbreken van zwangerschap (verrichting)"/>
-         </concept>
-         <concept>
-            <code value="271692001"/>
-            <display value="presenterend deel van foetus (waarneembare entiteit)"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4147 TypePartusWaarde"/>
+            </extension>
+            <code value="364336006"/>
+            <display value="soort partus (waarneembare entiteit)"/>
          </concept>
       </include>
       <include>
-         <system value="http://loinc.org" />
+         <system value="http://loinc.org"/>
       </include>
+      <!--peri32-dataelement-1197 VerrichtingType in profile "bc-ObstetricProcedure"
+          peri32-dataelement-1554 VerrichtingType in profile "bc-ObstetricProcedure"
+          peri32-dataelement-4147 TypePartusWaarde in profile "bc-BirthObservation"
+          peri31-dataelement-1456 VerrichtingType in profile "bc-ObstetricProcedure"
+          peri32-dataelement-1536 VerrichtingType in profile ""-->
+      <!--<concept>
+              <code value="386639001"/>
+              <display value="afbreken van zwangerschap (verrichting)"/>
+          </concept>-->
+      <!--=========================================================-->
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-ChildObservation-code.xml
+++ b/profiles/ValueSets/bc-ChildObservation-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-ChildObservation-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-ChildObservation-code"/>
    <title value="bc-ChildObservation-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-ChildObservation-code"/>
@@ -18,87 +17,137 @@
       <include>
          <system value="http://snomed.info/sct"/>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2941 HuidWaarde"/>
+            </extension>
             <code value="364528001"/>
             <display value="observatie betreffende huid (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2971 HoofdHalsWaarde"/>
+            </extension>
             <code value="364403006"/>
             <display value="observatie betreffende hoofd-halsregio (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2979 ThoraxWaarde"/>
+            </extension>
             <code value="364434005"/>
-            <display value=" aspect van thorax (waarneembare entiteit)"/>
+            <display value="aspect van thorax (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3072 AbdomenWaarde"/>
+            </extension>
             <code value="364446009"/>
             <display value="algemene kenmerken van abdomen (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3077 RugWaarde"/>
+            </extension>
             <code value="364415005"/>
             <display value="observatie betreffende wervelkolom (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3082 ExtremiteitenWaarde"/>
+            </extension>
             <code value="363799009"/>
             <display value="kenmerk van extremiteit (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3051 GenitaliaWaarde"/>
+            </extension>
             <code value="364204002"/>
             <display value="observatie betreffende geslachtsorgaan (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3087 NeurologieWaarde"/>
+            </extension>
             <code value="363820009"/>
             <display value="observatie betreffende neurologie (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="442618008 413083006"/>
-            <display value="afwijkende bevinding tijdens evaluatie (bevinding) automated auditory brainstem response test (verrichting)"/>
-         </concept>
-         <concept>
-            <code value="105421008"/>
-            <display value="opleidingsniveau (waarneembare entiteit)"/>
-         </concept>
-         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-9963 AdemhalingWaarde"/>
+            </extension>
             <code value="364062005"/>
             <display value="observatie betreffende ademhaling (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-9889 NavelstompWaarde"/>
+            </extension>
             <code value="364595007"/>
             <display value="aspect van navelstrengstomp (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-9899 SlaappatroonWaarde"/>
+            </extension>
             <code value="404950004"/>
             <display value="gedrag omtrent slaap (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-9909 HuilgedragWaarde"/>
+            </extension>
             <code value="28263002"/>
             <display value="huilen (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="248369007"/>
-            <display value="bevinding betreffende schedel (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="252957005"/>
-            <display value="gehoortest bij kind (verrichting)"/>
-         </concept>
-         <concept>
-            <code value="77262006"/>
-            <display value="hielprik (verrichting)"/>
-         </concept>
-         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-9919 SpugenWaarde"/>
+            </extension>
             <code value="300359004"/>
             <display value="bevinding betreffende braken (bevinding)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-9929 SchedelWaarde"/>
+            </extension>
+            <code value="248369007"/>
+            <display value="bevinding betreffende schedel (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10006 GehoortestWaarde"/>
+            </extension>
+            <code value="252957005"/>
+            <display value="gehoortest bij kind (verrichting)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10023 DatumGehoortestWaarde"/>
+            </extension>
+            <code value="439272007"/>
+            <display value="datum van verrichting (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10016 HielprikWaarde"/>
+            </extension>
+            <code value="77262006"/>
+            <display value="hielprik (verrichting)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10024 DatumHielprikWaarde"/>
+            </extension>
             <code value="439771001"/>
             <display value="datum van gebeurtenis (waarneembare entiteit)"/>
          </concept>
-      </include>
-      <include>
-         <system value="http://loinc.org"/>
          <concept>
-            <code value="8339-4"/>
-            <display value="Birth weight Measured"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10025 SetnummerHielprikWaarde"/>
+            </extension>
+            <code value="396278008"/>
+            <display value="identificatienummer (waarneembare entiteit)"/>
          </concept>
       </include>
    </compose>

--- a/profiles/ValueSets/bc-DeliveryObservation-code.xml
+++ b/profiles/ValueSets/bc-DeliveryObservation-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-DeliveryObservation-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-DeliveryObservation-code"/>
    <title value="bc-DeliveryObservation-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-DeliveryObservation-code"/>
@@ -18,52 +17,95 @@
       <include>
          <system value="http://snomed.info/sct"/>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3951 Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)"/>
+            </extension>
+            <code value="609625009"/>
+            <display value="bevinding betreffende bekkenregio van romp (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4087 BeginActieveOntsluitingWaarde"/>
+            </extension>
             <code value="160621000146107"/>
             <display value="datum van begin van eerste fase van partus (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4099 BeginBaringWaarde"/>
+            </extension>
             <code value="160611000146102"/>
             <display value="manier waarop eerste fase van partus is begonnen (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4111 BrekenVliezenWaarde"/>
+            </extension>
             <code value="289251005"/>
             <display value="tijdstip waarop gebroken vliezen zijn geconstateerd (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4123 Aard Vruchtwater Waarde"/>
+            </extension>
             <code value="168089007"/>
             <display value="aspect van vruchtwater (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4221 WijzeGeboortePlacentaWaarde"/>
+            </extension>
             <code value="236994008"/>
             <display value="geboorte van placenta (verrichting)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4233 GeboortePlacentaWaarde"/>
+            </extension>
             <code value="136311000146100"/>
             <display value="datum en tijd van geboorte van placenta (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4245 PlacentaCompleetWaarde"/>
+            </extension>
             <code value="364343000"/>
             <display value="compleetheid van placenta (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="364351002"/>
-            <display value="compleetheid van vruchtvliezen (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="249191003"/>
-            <display value="aantal bloedvaten in navelstreng (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="364332008"/>
-            <display value="bloedverlies durante partu (waarneembare entiteit)"/>
-         </concept>
-         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4257 PlacentaPAWaarde"/>
+            </extension>
             <code value="168123008"/>
             <display value="monster ingestuurd voor onderzoek (situatie)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4269 TestuitslagPAWaarde"/>
+            </extension>
             <code value="726566009"/>
             <display value="Pathology biopsy report (record artifact)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4281 CompleetheidVliezenWaarde"/>
+            </extension>
+            <code value="364351002"/>
+            <display value="compleetheid van vruchtvliezen (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4293 NavelstrengVatenWaarde"/>
+            </extension>
+            <code value="249191003"/>
+            <display value="aantal bloedvaten in navelstreng (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1751 HoeveelheidBloedverliesWaarde"/>
+            </extension>
+            <code value="364332008"/>
+            <display value="bloedverlies durante partu (waarneembare entiteit)"/>
          </concept>
       </include>
       <include>

--- a/profiles/ValueSets/bc-DisorderOfChild-code.xml
+++ b/profiles/ValueSets/bc-DisorderOfChild-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-DisorderOfChild-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-DisorderOfChild-code"/>
    <title value="bc-DisorderOfChild-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-DisorderOfChild-code"/>
@@ -16,82 +15,158 @@
    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
    <compose>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.369--20220214141440"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.325--20210518104806">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1507 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.341--20210225105013"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.324--20210518101158">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1507 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.325--20210518104806"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.295--20200810122858">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1507 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.324--20210518101158"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.327--20210518144535">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1497 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.295--20200810122858"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.326--20210518125239">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1497 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.327--20210518144535"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.296--20200811105755">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1497 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.326--20210518125239"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.299--20200824154514">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1518 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.296--20200811105755"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.328--20210520161536">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1518 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.299--20200824154514"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.298--20200824133956">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1518 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.328--20210520161536"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.327--20201201150957">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3063 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.298--20200824133956"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.325--20201130145716">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2958 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.231--20220120134819"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.329--20201201152941">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2999 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.3--20171231000000"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.330--20201203112705">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2989 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.337--20210628164200"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.331--20201203112757">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3010 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.260--20200407134908"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.332--20201203113344">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3021 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.253--20200401105232"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.333--20201203113910">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3032 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.283--20200527093520"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.334--20201203114624">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3043 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.359--20220131105223"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.369--20220214141440">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10686 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.360--20220131110025"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.341--20210225105013">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2700 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.361--20220131110815"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.260--20200407134908">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3924 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.362--20220131111328"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.253--20200401105232">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3934 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.363--20220131112406"/>
-      </include>
-      <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.364--20220131113252"/>
-      </include>
-      <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.365--20220131114808"/>
-      </include>
-      <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.366--20220131115327"/>
-      </include>
-      <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.367--20220131120004"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.283--20200527093520">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3944 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-DisorderOfLaborAndDelivery-code.xml
+++ b/profiles/ValueSets/bc-DisorderOfLaborAndDelivery-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-DisorderOfLaborAndDelivery-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-DisorderOfLaborAndDelivery-code"/>
    <title value="bc-DisorderOfLaborAndDelivery-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-DisorderOfLaborAndDelivery-code"/>
@@ -16,10 +15,28 @@
    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
    <compose>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.289--20200127101358"/>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1566 ProbleemLateraliteit"/>
+            </extension>
+            <code value="272741003"/>
+            <display value="lateraliteit (attribuut)"/>
+         </concept>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.304--20200213111855"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.304--20200213111855">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1595 ProbleemNaam"/>
+            </extension>
+         </valueSet>
+      </include>
+      <include>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.289--20200127101358">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1568 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-DisorderOfPregnancy-code.xml
+++ b/profiles/ValueSets/bc-DisorderOfPregnancy-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-DisorderOfPregnancy-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-DisorderOfPregnancy-code"/>
    <title value="bc-DisorderOfPregnancy-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-DisorderOfPregnancy-code"/>
@@ -16,10 +15,18 @@
    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
    <compose>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.302--20200211092928"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.302--20200211092928">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1184 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.214--20160125115042"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.214--20160125115042">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2464 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-DisorderPostPartum-code.xml
+++ b/profiles/ValueSets/bc-DisorderPostPartum-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-DisorderPostPartum-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-DisorderPostPartum-code"/>
    <title value="bc-DisorderPostPartum-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-DisorderPostPartum-code"/>
@@ -16,13 +15,32 @@
    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
    <compose>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.34--20210413094135"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.289--20200127101358">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1568 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.3--20171231000000"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.34--20210413094135">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2309 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.322--20201124115905"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.3--20171231000000">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2309 ProbleemNaam"/>
+            </extension>
+         </valueSet>
+      </include>
+      <include>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.322--20201124115905">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2848 ProbleemNaam"/>
+            </extension>
+         </valueSet>
       </include>
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-FetusObservation-code.xml
+++ b/profiles/ValueSets/bc-FetusObservation-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-FetusObservation-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-FetusObservation-code"/>
    <title value="bc-FetusObservation-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-FetusObservation-code"/>
@@ -18,16 +17,25 @@
       <include>
          <system value="http://snomed.info/sct"/>
          <concept>
-            <code value="281568006"/>
-            <display value="monitoren van foetale hart (regime/therapie)"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4172 LiggingKindWaarde"/>
+            </extension>
+            <code value="271692001"/>
+            <display value="presenterend deel van foetus (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10951 LiggingFoetusWaarde"/>
+            </extension>
+            <code value="249062004"/>
+            <display value="ligging van foetus (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2407 BewegingFoetusWaarde"/>
+            </extension>
             <code value="364619008"/>
-            <display value=" meetbare observatie betreffende foetale bewegingen (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="441742003"/>
-            <display value="beoordeling van bevinding (bevinding)"/>
+            <display value="meetbare observatie betreffende foetale bewegingen (waarneembare entiteit)"/>
          </concept>
          <concept>
             <code value="271692001"/>
@@ -37,43 +45,103 @@
       <include>
          <system value="http://loinc.org"/>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3515 ACWaarde"/>
+            </extension>
             <code value="11979-2"/>
-            <display value="Fetal Abdomen Circumference US"/>
+            <display value="Omtrek [afmeting] in abdomen^foetus d.m.v. echografische bepaling"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3525 ACPercentielWaarde"/>
+            </extension>
+            <code value="96125-0"/>
+            <display value="Fetal abdomen circumference percentile based on per estimated gestational age"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3541 FLWaarde"/>
+            </extension>
             <code value="11963-6"/>
             <display value="Fetal Femur diaphysis [Length] US"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3551 FLPercentielWaarde"/>
+            </extension>
+            <code value="96124-3"/>
+            <display value="Fetal femur diaphysis length percentile per estimated gestational age"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3554 BPDWaarde"/>
+            </extension>
             <code value="11820-8"/>
             <display value="Fetal Head Diameter.biparietal US"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3566 LBDWaarde"/>
+            </extension>
             <code value="11815-8"/>
-            <display value="Fetal Urinary bladder Diameter US"/>
+            <display value="Diameter [afmeting] in blaas^foetus d.m.v. echografische bepaling"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3578 CRLWaarde"/>
+            </extension>
             <code value="11957-8"/>
             <display value="Fetal Crown Rump length US"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3588 CRLPercentielWaarde"/>
+            </extension>
+            <code value="95939-5"/>
+            <display value="Fetal Crown Rump length [Percentile]"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3591 TCDWaarde"/>
+            </extension>
             <code value="11863-8"/>
             <display value="Fetal Cerebellum Diameter transverse US"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3601 TCDPercentielWaarde"/>
+            </extension>
+            <code value="95938-7"/>
+            <display value="Fetal Cerebellum Diameter transverse [Percentile]"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3604 NTWaarde"/>
+            </extension>
             <code value="12146-7"/>
             <display value="Fetal Nuchal fold Thickness US"/>
          </concept>
          <concept>
-            <code value="89087-1"/>
-            <display value="Fetal Body weight Estimated"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3616 EFWWaarde"/>
+            </extension>
+            <code value="11727-5"/>
+            <display value="Fetal Body weight estimated by US"/>
          </concept>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.322--20210506140617"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.322--20210506140617">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-7887 ObservatieNaam"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.323--20210506154515"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.323--20210506154515">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-7886 SonomarkerNaam"/>
+            </extension>
+         </valueSet>
       </include>
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-MaternalObservation-code.xml
+++ b/profiles/ValueSets/bc-MaternalObservation-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-MaternalObservation-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-MaternalObservation-code"/>
    <title value="bc-MaternalObservation-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-MaternalObservation-code"/>
@@ -16,186 +15,311 @@
    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
    <compose>
       <include>
-         <system value="http://loinc.org"/>
-         <concept>
-            <code value="39156-5"/>
-            <display value="Body mass index (BMI) [Ratio]"/>
-         </concept>
-         <concept>
-            <code value="11881-0"/>
-            <display value="Uterus Fundal height Tape measure"/>
-         </concept>
-      </include>
-      <include>
          <system value="http://snomed.info/sct"/>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2582 Schooltype"/>
+            </extension>
+            <code value="105421008"/>
+         <display value="opleidingsniveau (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3407 Consanguïniteit (Observatie)"/>
+            </extension>
+         <code value="842009"/>
+            <display value="consanguiniteit (bevinding)"/>
+         </concept>
+      <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2913 SociaalNetwerk"/>
+            </extension>
             <code value="365469004"/>
             <display value="bevinding betreffende netwerk van gezin, familie en ondersteuners (bevinding)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1742 Foliumzuurgebruik (Observatie)"/>
+            </extension>
             <code value="792807003"/>
             <display value="intake van foliumzuur (waarneembare entiteit)"/>
          </concept>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4370 KinkhoestvaccinatieWaarde"/>
+            </extension>
             <code value="39343008"/>
             <display value="vaccinatie tegen kinkhoest (verrichting)"/>
          </concept>
          <concept>
-            <code value="142961000146102"/>
-            <display value="plaats van voorkeur voor bevalling (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="159821000146107"/>
-            <display value="lijn in gezondheidszorg (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="169740003"/>
-            <display value="wijze van voeden van zuigeling (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="142981000146105"/>
-            <display value="voorgenomen achternaam voor neonaat"/>
-         </concept>
-         <concept>
-            <code value="147771000146108"/>
-            <display value="zorgafnemer heeft kraamzorg aangevraagd (situatie)"/>
-         </concept>
-         <concept>
-            <code value="160631000146109"/>
-            <display value="geïndiceerd aantal uur kraamzorg (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="364265003"/>
-            <display value="&#x9;hoogte van uterus gravidus (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="249062004"/>
-            <display value="ligging van foetus (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="364611006"/>
-            <display value="indaling van foetus ten opzichte van spinae ischiadicae (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="248918004"/>
-            <display value="lengte van cervix uteri (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="7751000146103"/>
-            <display value="niet-invasieve prenatale test (verrichting)"/>
-         </concept>
-         <concept>
-            <code value="249021005"/>
-            <display value="verstrijking van cervix uteri (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="248920001"/>
-            <display value="positie van cervix uteri (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="289761004"/>
-            <display value="bevinding betreffende ontsluiting (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="112074005"/>
-            <display value="bevinding betreffende foetaal membraan (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="364612004"/>
-            <display value="voorliggend deel palpabel bij vaginaal toucher (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="289388006"/>
-            <display value="bevinding betreffende palpabel voorliggend deel bij vaginaal toucher (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="249278006"/>
-            <display value="vermogen tot mictie (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="111989001"/>
-            <display value="defecatie (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="249211006"/>
-            <display value="bevinding betreffende lochia (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="276375002"/>
-            <display value="stinkende lochia (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="146381000146107"/>
-            <display value="grote bloedstolsels in lochia (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="31781000146105"/>
-            <display value=" &#x9;wond na sectio caesarea (afwijkende morfologie)"/>
-         </concept>
-         <concept>
-            <code value="405009004"/>
-            <display value="infectiestatus (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="298007001"/>
-            <display value="vochtigheid van verwonding (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="449747006"/>
-            <display value="bevinding betreffende rand van wond (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="401238003"/>
-            <display value="lengte van verwonding (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="401239006"/>
-            <display value="breedte van verwonding (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="425094009"/>
-            <display value="diepte van verwonding (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="116312005"/>
-            <display value="bevinding betreffende onderste extremiteit (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="118791000146100"/>
-            <display value="voorlichten over toedienen van vitamine D (verrichting)"/>
-         </concept>
-         <concept>
-            <code value="276319003"/>
-            <display value="bevinding betreffende menstruatie (bevinding)"/>
-         </concept>
-         <concept>
-            <code value="129009001"/>
-            <display value="blaascontrole (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="129008009"/>
-            <display value="darmcontrole (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="364297003"/>
-            <display value="observatie betreffende perineum van vrouw (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="1186606009"/>
-            <display value="observatie betreffende verzoek van patiënt (waarneembare entiteit)"/>
-         </concept>
-         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10273 TrisomieAnamneseWaarde"/>
+            </extension>
             <code value="390281000146101"/>
             <display value="voorgeschiedenis met trisomie en partiële trisomie van autosoom (situatie)"/>
          </concept>
          <concept>
-            <code value="105421008"/>
-            <display value="opleidingsniveau (waarneembare entiteit)"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2255 VoorgenomenPlaatsBaringWaarde"/>
+            </extension>
+            <code value="142961000146102"/>
+            <display value="voorkeur voor locatie van bevalling (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="570931000146101"/>
-            <display value="hoeveelheid gebruikte kraamverbanden (waarneembare entiteit)"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3337 VoorgenomenEchelonWaarde"/>
+            </extension>
+            <code value="159821000146107"/>
+            <display value="lijn in gezondheidszorg (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2275 VoorgenomenAchternaamWaarde"/>
+            </extension>
+            <code value="142981000146105"/>
+            <display value="voorgenomen achternaam voor neonaat"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2277 KraamzorgAangevraagdWaarde"/>
+            </extension>
+            <code value="147771000146108"/>
+            <display value="zorgafnemer heeft kraamzorg aangevraagd (situatie)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10745 GeïndiceerdAantalUurKraamzorgWaarde"/>
+            </extension>
+            <code value="160631000146109"/>
+            <display value="geïndiceerd aantal uur kraamzorg (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4050 FundusstandWaarde"/>
+            </extension>
+            <code value="364265003"/>
+            <display value="hoogte van uterus gravidus (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4062 LiggingFoetusWaarde"/>
+            </extension>
+            <code value="249062004"/>
+            <display value="ligging van foetus (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4074 IndalingFoetusWaarde"/>
+            </extension>
+            <code value="364611006"/>
+            <display value="indaling van foetus ten opzichte van spinae ischiadicae (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3637 CervixlengteWaarde"/>
+            </extension>
+            <code value="248918004"/>
+            <display value="lengte van cervix uteri (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10896 NIPT"/>
+            </extension>
+            <code value="7751000146103"/>
+            <display value="niet-invasieve prenatale test (verrichting)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3680 PortioWaarde"/>
+            </extension>
+            <code value="249021005"/>
+            <display value="verstrijking van cervix uteri (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3693 PositiePortioWaarde"/>
+            </extension>
+            <code value="248920001"/>
+            <display value="positie van cervix uteri (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3705 OntsluitingWaarde"/>
+            </extension>
+            <code value="289761004"/>
+            <display value="bevinding betreffende ontsluiting (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3717 VliezenWaarde"/>
+            </extension>
+            <code value="112074005"/>
+            <display value="bevinding betreffende foetaal membraan (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3741 AardVoorliggendDeelWaarde"/>
+            </extension>
+            <code value="364612004"/>
+            <display value="voorliggend deel palpabel bij vaginaal toucher (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3753 StandWaarde"/>
+            </extension>
+            <code value="289388006"/>
+            <display value="bevinding betreffende palpabel voorliggend deel bij vaginaal toucher (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10774 UrinatieGeweest?"/>
+            </extension>
+            <code value="249278006"/>
+            <display value="vermogen tot mictie (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10775 DefecatieGeweest?"/>
+            </extension>
+            <code value="111989001"/>
+            <display value="defecatie (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3108 Lochia (Observatie)"/>
+            </extension>
+            <code value="249211006"/>
+            <display value="bevinding betreffende lochia (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3115 Lochia foetide / riekend? (Waarde)"/>
+            </extension>
+            <code value="276375002"/>
+            <display value="stinkende lochia (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3117 Grote stolsels in lochia (Waarde)"/>
+            </extension>
+            <code value="146381000146107"/>
+            <display value="grote bloedstolsels in lochia (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3120 Sectiowond (Wond)"/>
+            </extension>
+            <code value="31781000146105"/>
+            <display value="&#x9;wond na sectio caesarea (afwijkende morfologie)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2869 ObservatieWaarde"/>
+            </extension>
+            <code value="116312005"/>
+            <display value="bevinding betreffende onderste extremiteit (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2825 ControlePerineumWaarde"/>
+            </extension>
+            <code value="124734007"/>
+            <display value="bevinding betreffende perineum (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2871 Perineumwond (Wond)"/>
+            </extension>
+            <code value="210484005"/>
+            <display value="wond van perineum (aandoening)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10223 VoorlichtingVeiligSlapenWaarde"/>
+            </extension>
+            <code value="1263932002"/>
+            <display value="voorlichten over slaap (verrichting)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10233 VoorlichtingVitamineDWaarde"/>
+            </extension>
+            <code value="118791000146100"/>
+            <display value="voorlichten over toedienen van vitamine D (verrichting)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-7986 MenstruatieWaarde"/>
+            </extension>
+            <code value="276319003"/>
+            <display value="bevinding betreffende menstruatie (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-7971 UrineContinentie"/>
+            </extension>
+            <code value="129009001"/>
+            <display value="blaascontrole (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-7972 FecesContinentie"/>
+            </extension>
+            <code value="129008009"/>
+            <display value="darmcontrole (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-10675 Flatusincontinentie"/>
+            </extension>
+            <code value="249508009"/>
+            <display value="flatusincontinentie (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-7953 ConditiePerineumWaarde"/>
+            </extension>
+            <code value="364297003"/>
+            <display value="observatie betreffende perineum van vrouw (waarneembare entiteit)"/>
          </concept>
       </include>
+      <include>
+         <system value="http://loinc.org"/>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3429 BMIWaarde"/>
+            </extension>
+            <code value="39156-5"/>
+            <display value="Body mass index (BMI) [Ratio]"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3417 FundushoogteWaarde"/>
+            </extension>
+            <code value="11881-0"/>
+         <display value="Uterus Fundal height Tape measure"/>
+         </concept>
+      </include>
+   <!--peri32-dataelement-3123 WondInfectie in profile "bc-MaternalObservation"
+          peri32-dataelement-2874 WondInfectie in profile "bc-MaternalObservation"-->
+      <!--<concept>
+              <code value="405009004"/>
+              <display value="infectiestatus (waarneembare entiteit)"/>
+          </concept>-->
+      <!--=========================================================-->
+      <!--peri32-dataelement-3124 WondVochtigheid in profile "bc-MaternalObservation"
+          peri32-dataelement-2875 WondVochtigheid in profile "bc-MaternalObservation"-->
+      <!--<concept>
+              <code value="298007001"/>
+              <display value="vochtigheid van verwonding (waarneembare entiteit)"/>
+          </concept>-->
+      <!--=========================================================-->
+      <!--peri32-dataelement-3125 WondRand in profile "bc-MaternalObservation"
+          peri32-dataelement-2876 WondRand in profile "bc-MaternalObservation"-->
+      <!--<concept>
+              <code value="449747006"/>
+              <display value="bevinding betreffende rand van wond (bevinding)"/>
+          </concept>-->
+      <!--=========================================================-->
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-ObstetricProcedure-code.xml
+++ b/profiles/ValueSets/bc-ObstetricProcedure-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-ObstetricProcedure-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-ObstetricProcedure-code"/>
    <title value="bc-ObstetricProcedure-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-ObstetricProcedure-code"/>
@@ -16,37 +15,109 @@
    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
    <compose>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.375--20220321094419"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.375--20220321094419">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1197 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.307--20200226094046"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.307--20200226094046">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1197 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.303--20200213102349"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.303--20200213102349">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1554 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.375--20220321094419"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.316--20201102145334">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2322 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.288--20200123134654"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.14.1.2--20171231000000">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2322 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.375--20220321094419"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.288--20200123134654">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1610 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.333--20210615102522"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.243--20181004181347">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3098 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.329--20210525162006"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.300--20200204163147">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-1087 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.229--20181012134434"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.380--20221124152240">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri31-dataelement-1439 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.255--20200406115120"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.290--20221124151231">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri31-dataelement-1456 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
       <include>
-         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.375--20220321094419"/>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.333--20210615102522">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri31-dataelement-1456 VerrichtingType"/>
+            </extension>
+         </valueSet>
+      </include>
+      <include>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.312--20210208151257">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri31-dataelement-1456 VerrichtingType"/>
+            </extension>
+         </valueSet>
+      </include>
+      <include>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.329--20210525162006">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri31-dataelement-1456 VerrichtingType"/>
+            </extension>
+         </valueSet>
+      </include>
+      <include>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.229--20230802100559">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-8767 VerrichtingType"/>
+            </extension>
+         </valueSet>
+      </include>
+      <include>
+         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.255--20200406115120">
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2423 VerrichtingType"/>
+            </extension>
+         </valueSet>
       </include>
    </compose>
 </ValueSet>

--- a/profiles/ValueSets/bc-PregnancyObservation-code.xml
+++ b/profiles/ValueSets/bc-PregnancyObservation-code.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="bc-PregnancyObservation-code"/>
    <meta>
@@ -8,7 +7,7 @@
    <version value="1.3.3"/>
    <name value="bc-PregnancyObservation-code"/>
    <title value="bc-PregnancyObservation-code"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Nictiz"/>
    <description value="bc-PregnancyObservation-code"/>
@@ -18,64 +17,60 @@
       <include>
          <system value="http://snomed.info/sct"/>
          <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-3347 ATermeDatum"/>
+            </extension>
             <code value="161714006"/>
             <display value="geschatte datum van partus (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="118951000146109"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+            <valueString value="peri32-dataelement-1729 Datum einde zwangerschap"/>
+         </extension>
+         <code value="118951000146109"/>
             <display value="datum van einde van zwangerschap (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="147781000146105"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+            <valueString value="peri32-dataelement-2223 Definitieve à terme Waarde"/>
+         </extension>
+         <code value="147781000146105"/>
             <display value="definitieve uitgerekende datum van partus (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="246435002"/>
-            <display value="aantal foetussen (waarneembare entiteit)"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+            <valueString value="peri32-dataelement-2231 TweelingzwangerschapWaarde"/>
+         </extension>
+         <code value="65147003"/>
+            <display value="tweelingzwangerschap (bevinding)"/>
          </concept>
          <concept>
-            <code value="65147003"/>
-            <display value="tweelingzwangerschap (aandoening)"/>
-         </concept>
-         <concept>
-            <code value="143881000146107"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+            <valueString value="peri32-dataelement-1740 AantalLevendeKinderenWaarde"/>
+         </extension>
+         <code value="143881000146107"/>
             <display value="aantal levende nakomelingen (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="713651007"/>
-            <display value="voorgeschiedenis met zwangerschap met abortus als resultaat (situatie)"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+            <valueString value="peri32-dataelement-1820 FetalLossWaarde"/>
+         </extension>
+         <code value="16216731000119106"/>
+            <display value="voorgeschiedenis met eerdere zwangerschap met intra-uteriene foetale dood (situatie)"/>
          </concept>
          <concept>
-            <code value="364618000"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+            <valueString value="peri32-dataelement-2137 LevenVoelenWaarde"/>
+         </extension>
+         <code value="364618000"/>
             <display value="bewegingspatroon van foetus (waarneembare entiteit)"/>
          </concept>
          <concept>
-            <code value="142931000146106"/>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+            <valueString value="peri32-dataelement-2146 ActueelAantalLevendeFoetusWaarde"/>
+         </extension>
+         <code value="142931000146106"/>
             <display value="aantal levende foetussen (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="59283008"/>
-            <display value="maternale sterfte (gebeurtenis)"/>
-         </concept>
-         <concept>
-            <code value="276507005"/>
-            <display value="foetale sterfte (gebeurtenis)"/>
-         </concept>
-         <concept>
-            <code value="276506001"/>
-            <display value="neonatale sterfte (gebeurtenis)"/>
-         </concept>
-         <concept>
-            <code value="399753006"/>
-            <display value="datum van overlijden (waarneembare entiteit)"/>
-         </concept>
-         <concept>
-            <code value="386639001"/>
-            <display value="afbreken van zwangerschap (verrichting)"/>
-         </concept>
-         <concept>
-            <code value="16216731000119106"/>
-            <display value="voorgeschiedenis met eerdere zwangerschap met intra-uteriene foetale dood (situatie)"/>
          </concept>
       </include>
       <include>

--- a/profiles/bc-AbilityToTakeCareOfChild.xml
+++ b/profiles/bc-AbilityToTakeCareOfChild.xml
@@ -43,9 +43,8 @@
         <code value="129879003" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-9983" />
@@ -97,9 +96,8 @@
         <code value="160351000146107" />
       </patternCoding>
     </element>
-    <element id="Observation.component:uncertainty.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:uncertainty.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -128,9 +126,8 @@
         <code value="160341000146109" />
       </patternCoding>
     </element>
-    <element id="Observation.component:ability.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:ability.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/bc-AmnioticFluid.xml
+++ b/profiles/bc-AmnioticFluid.xml
@@ -43,14 +43,17 @@
         <code value="160321000146103" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2411" />
         <comment value="MeetDatumTijd" />
       </mapping>
+    </element>
+    <element id="Observation.effective[x]:effectiveDateTime">
+      <path value="Observation.effective[x]" />
+      <sliceName value="effectiveDateTime" />
     </element>
     <element id="Observation.comment">
       <path value="Observation.comment" />
@@ -75,16 +78,6 @@
         <code value="278292003" />
       </patternCoding>
     </element>
-    <element id="Observation.component">
-      <path value="Observation.component" />
-      <slicing>
-        <discriminator>
-          <type value="pattern" />
-          <path value="code" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
     <element id="Observation.component:amnioticFluidQuantity">
       <path value="Observation.component" />
       <sliceName value="amnioticFluidQuantity" />
@@ -97,9 +90,8 @@
         <code value="364354005" />
       </patternCoding>
     </element>
-    <element id="Observation.component:amnioticFluidQuantity.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:amnioticFluidQuantity.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -108,16 +100,6 @@
         <map value="peri32-dataelement-2413" />
         <comment value="HoeveelheidVruchtwaterWaarde" />
       </mapping>
-    </element>
-    <element id="Observation.component:amnioticFluidQuantity.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
-      <binding>
-        <strength value="extensible" />
-        <description value="Vruchtwater" />
-        <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.191--20140121165337" />
-        </valueSetReference>
-      </binding>
     </element>
     <element id="Observation.component:amnioticFluidCompartment">
       <path value="Observation.component" />
@@ -131,9 +113,8 @@
         <code value="249129009" />
       </patternCoding>
     </element>
-    <element id="Observation.component:amnioticFluidCompartment.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:amnioticFluidCompartment.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -142,14 +123,6 @@
         <map value="peri32-dataelement-2479" />
         <comment value="VruchtwatercompartimentWaarde" />
       </mapping>
-    </element>
-    <element id="Observation.component:amnioticFluidCompartment.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
-      <binding>
-        <strength value="extensible" />
-        <description value="BeoordelingBevindingen" />
-        <valueSetUri value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.23--20140904000000" />
-      </binding>
     </element>
     <element id="Observation.component:amnioticFluidSDP">
       <path value="Observation.component" />
@@ -163,9 +136,8 @@
         <code value="160301000146106" />
       </patternCoding>
     </element>
-    <element id="Observation.component:amnioticFluidSDP.value[x]:valueQuantity">
-      <path value="Observation.component.valueQuantity" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:amnioticFluidSDP.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="Quantity" />
       </type>
@@ -187,9 +159,8 @@
         <code value="160311000146108" />
       </patternCoding>
     </element>
-    <element id="Observation.component:amnioticFluidAFI.value[x]:valueQuantity">
-      <path value="Observation.component.valueQuantity" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:amnioticFluidAFI.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="Quantity" />
       </type>

--- a/profiles/bc-BarthelIndex.xml
+++ b/profiles/bc-BarthelIndex.xml
@@ -1,421 +1,391 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="bc-BarthelIndex" />
-  <url value="http://nictiz.nl/fhir/StructureDefinition/bc-BarthelIndex" />
-  <version value="1.3.3" />
-  <name value="bc-BarthelIndex" />
-  <title value="bc-BarthelIndex" />
-  <status value="active" />
-  <publisher value="Nictiz" />
+  <id value="bc-BarthelIndex"/>
+  <url value="http://nictiz.nl/fhir/StructureDefinition/bc-BarthelIndex"/>
+  <version value="1.3.3"/>
+  <name value="bc-BarthelIndex"/>
+  <title value="bc-BarthelIndex"/>
+  <status value="active"/>
+  <publisher value="Nictiz"/>
   <contact>
-    <name value="Nictiz" />
+    <name value="Nictiz"/>
     <telecom>
-      <system value="email" />
-      <value value="geboortezorg@nictiz.nl" />
-      <use value="work" />
+      <system value="email"/>
+      <value value="geboortezorg@nictiz.nl"/>
+      <use value="work"/>
     </telecom>
   </contact>
-  <description value="An Observation profile describing self-reliance of the woman after birth as defined by BabyConnect. The subject is the woman Patient." />
-  <copyright value="CC0" />
-  <fhirVersion value="3.0.2" />
+  <description value="An Observation profile describing self-reliance of the woman after birth as defined by BabyConnect. The subject is the woman Patient."/>
+  <copyright value="CC0"/>
+  <fhirVersion value="3.0.2"/>
   <mapping>
-    <identity value="gebz-peri-v3.2" />
-    <uri value="https://decor.nictiz.nl/art-decor/decor-datasets-\-peri20-?id=2.16.840.1.113883.2.4.3.11.60.90.77.1.6&amp;effectiveDate=2016-09-08T00%3A00%3A00&amp;conceptId=2.16.840.1.113883.2.4.3.11.60.90.77.2.6.4&amp;conceptEffectiveDate=2016-09-08T00%3A00%3A00" />
-    <name value="Geboortezorg 3.2" />
+    <identity value="gebz-peri-v3.2"/>
+    <uri value="https://decor.nictiz.nl/art-decor/decor-datasets-\-peri20-?id=2.16.840.1.113883.2.4.3.11.60.90.77.1.6&amp;effectiveDate=2016-09-08T00%3A00%3A00&amp;conceptId=2.16.840.1.113883.2.4.3.11.60.90.77.2.6.4&amp;conceptEffectiveDate=2016-09-08T00%3A00%3A00"/>
+    <name value="Geboortezorg 3.2"/>
   </mapping>
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Observation" />
-  <baseDefinition value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation" />
-  <derivation value="constraint" />
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="Observation"/>
+  <baseDefinition value="http://nictiz.nl/fhir/StructureDefinition/bc-MaternalObservation"/>
+  <derivation value="constraint"/>
   <differential>
     <element id="Observation">
-      <path value="Observation" />
+      <path value="Observation"/>
       <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2812" />
-        <comment value="BarthelIndex" />
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2812"/>
+        <comment value="BarthelIndex"/>
       </mapping>
     </element>
     <element id="Observation.code.coding">
-      <path value="Observation.code.coding" />
+      <path value="Observation.code.coding"/>
+      <slicing>
+        <discriminator>
+          <type value="pattern"/>
+          <path value="$this"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="Observation.code.coding:barthelIndex">
+      <path value="Observation.code.coding"/>
+      <sliceName value="barthelIndex"/>
       <patternCoding>
-        <system value="http://snomed.info/sct" />
-        <code value="273302005" />
+        <system value="http://snomed.info/sct"/>
+        <code value="273302005"/>
       </patternCoding>
     </element>
     <element id="Observation.component">
-      <path value="Observation.component" />
+      <path value="Observation.component"/>
       <slicing>
         <discriminator>
-          <type value="pattern" />
-          <path value="code" />
+          <type value="pattern"/>
+          <path value="code.coding"/>
         </discriminator>
-        <rules value="open" />
+        <rules value="open"/>
       </slicing>
     </element>
     <element id="Observation.component:bowel">
-      <path value="Observation.component" />
-      <sliceName value="bowel" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="bowel"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:bowel.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002004" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002004"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:bowel.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:bowel.value[x]">
+      <path value="Observation.component.value[x]"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2813" />
-        <comment value="Darm" />
-      </mapping>
-    </element>
-    <element id="Observation.component:bowel.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="DarmCodelijst" />
+        <strength value="extensible"/>
+        <description value="DarmCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.1--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.1--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2813"/>
+        <comment value="Darm"/>
+      </mapping>
     </element>
     <element id="Observation.component:bladder">
-      <path value="Observation.component" />
-      <sliceName value="bladder" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="bladder"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:bladder.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002003" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002003"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:bladder.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:bladder.value[x]">
+      <path value="Observation.component.value[x]"/>
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2814" />
-        <comment value="Blaas" />
-      </mapping>
-    </element>
-    <element id="Observation.component:bladder.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="BlaasCodelijst" />
+        <strength value="extensible"/>
+        <description value="BlaasCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.2--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.2--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2814"/>
+        <comment value="Blaas"/>
+      </mapping>
     </element>
     <element id="Observation.component:personalGrooming">
-      <path value="Observation.component" />
-      <sliceName value="personalGrooming" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="personalGrooming"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:personalGrooming.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002005" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002005"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:personalGrooming.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:personalGrooming.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2815" />
-        <comment value="UiterlijkeVerzorging" />
-      </mapping>
-    </element>
-    <element id="Observation.component:personalGrooming.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="UiterlijkeVerzorgingCodelijst" />
+        <strength value="extensible"/>
+        <description value="UiterlijkeVerzorgingCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.3--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.3--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2815"/>
+        <comment value="UiterlijkeVerzorging"/>
+      </mapping>
     </element>
     <element id="Observation.component:toiletUse">
-      <path value="Observation.component" />
-      <sliceName value="toiletUse" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="toiletUse"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:toiletUse.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002006" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002006"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:toiletUse.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:toiletUse.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2816" />
-        <comment value="Toiletgebruik" />
-      </mapping>
-    </element>
-    <element id="Observation.component:toiletUse.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="ToiletgebruikCodelijst" />
+        <strength value="extensible"/>
+        <description value="ToiletgebruikCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.4--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.4--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2816"/>
+        <comment value="Toiletgebruik"/>
+      </mapping>
     </element>
     <element id="Observation.component:eating">
-      <path value="Observation.component" />
-      <sliceName value="eating" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="eating"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:eating.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002007" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002007"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:eating.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:eating.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2817" />
-        <comment value="Eten" />
-      </mapping>
-    </element>
-    <element id="Observation.component:eating.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="EtenCodelijst" />
+        <strength value="extensible"/>
+        <description value="EtenCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.5--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.5--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2817"/>
+        <comment value="Eten"/>
+      </mapping>
     </element>
     <element id="Observation.component:transfers">
-      <path value="Observation.component" />
-      <sliceName value="transfers" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="transfers"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:transfers.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002008" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002008"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:transfers.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:transfers.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2818" />
-        <comment value="Transfers" />
-      </mapping>
-    </element>
-    <element id="Observation.component:transfers.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="TransfersCodelijst" />
+        <strength value="extensible"/>
+        <description value="TransfersCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.6--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.6--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2818"/>
+        <comment value="Transfers"/>
+      </mapping>
     </element>
     <element id="Observation.component:mobility">
-      <path value="Observation.component" />
-      <sliceName value="mobility" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="mobility"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:mobility.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002009" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002009"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:mobility.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:mobility.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2819" />
-        <comment value="Mobiliteit" />
-      </mapping>
-    </element>
-    <element id="Observation.component:mobility.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="MobiliteitCodelijst" />
+        <strength value="extensible"/>
+        <description value="MobiliteitCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.7--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.7--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2819"/>
+        <comment value="Mobiliteit"/>
+      </mapping>
     </element>
     <element id="Observation.component:dressingAndUndressing">
-      <path value="Observation.component" />
-      <sliceName value="dressingAndUndressing" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="dressingAndUndressing"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:dressingAndUndressing.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002010" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002010"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:dressingAndUndressing.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:dressingAndUndressing.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2820" />
-        <comment value="AanUitkleden" />
-      </mapping>
-    </element>
-    <element id="Observation.component:dressingAndUndressing.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="AanUitKledenCodelijst" />
+        <strength value="extensible"/>
+        <description value="AanUitKledenCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.8--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.8--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2820"/>
+        <comment value="AanUitkleden"/>
+      </mapping>
     </element>
     <element id="Observation.component:walkingStairs">
-      <path value="Observation.component" />
-      <sliceName value="walkingStairs" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="walkingStairs"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:walkingStairs.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002011" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002011"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:walkingStairs.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:walkingStairs.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2821" />
-        <comment value="TrappenLopen" />
-      </mapping>
-    </element>
-    <element id="Observation.component:walkingStairs.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="TrappenLopenCodelijst" />
+        <strength value="extensible"/>
+        <description value="TrappenLopenCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.9--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.9--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2821"/>
+        <comment value="TrappenLopen"/>
+      </mapping>
     </element>
     <element id="Observation.component:bathingAndShowering">
-      <path value="Observation.component" />
-      <sliceName value="bathingAndShowering" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="bathingAndShowering"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:bathingAndShowering.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1" />
-        <code value="4002012" />
+        <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
+        <code value="4002012"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:bathingAndShowering.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:bathingAndShowering.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="CodeableConcept"/>
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2822" />
-        <comment value="BadenDouchen" />
-      </mapping>
-    </element>
-    <element id="Observation.component:bathingAndShowering.value[x]:valueCodeableConcept.coding">
-      <path value="Observation.component.valueCodeableConcept.coding" />
       <binding>
-        <strength value="extensible" />
-        <description value="BadenDouchenCodelijst" />
+        <strength value="extensible"/>
+        <description value="BadenDouchenCodelijst"/>
         <valueSetReference>
-          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.10--20200901000000" />
+          <reference value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.2.10--20200901000000"/>
         </valueSetReference>
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2822"/>
+        <comment value="BadenDouchen"/>
+      </mapping>
     </element>
     <element id="Observation.component:totalScore">
-      <path value="Observation.component" />
-      <sliceName value="totalScore" />
-      <max value="1" />
+      <path value="Observation.component"/>
+      <sliceName value="totalScore"/>
+      <max value="1"/>
     </element>
     <element id="Observation.component:totalScore.code.coding">
-      <path value="Observation.component.code.coding" />
+      <path value="Observation.component.code.coding"/>
       <patternCoding>
-        <system value="http://snomed.info/sct" />
-        <code value="273302005" />
+        <system value="http://snomed.info/sct"/>
+        <code value="273302005"/>
       </patternCoding>
     </element>
-    <element id="Observation.component:totalScore.value[x]:valueQuantity">
-      <path value="Observation.component.value[x]" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:totalScore.value[x]">
+      <path value="Observation.component.value[x]"/>
       <type>
-        <code value="Quantity" />
+        <code value="Quantity"/>
       </type>
       <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2823" />
-        <comment value="TotaalScore" />
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-2823"/>
+        <comment value="TotaalScore"/>
       </mapping>
     </element>
   </differential>

--- a/profiles/bc-Birth.xml
+++ b/profiles/bc-Birth.xml
@@ -123,12 +123,15 @@
       <path value="Procedure.code" />
       <min value="1" />
     </element>
-    <element id="Procedure.code.coding:birth">
+    <element id="Procedure.code.coding">
       <path value="Procedure.code.coding" />
-      <sliceName value="birth" />
       <min value="1" />
     </element>
-    <element id="Procedure.code.coding:birth.code">
+    <element id="Procedure.code.coding.system">
+      <path value="Procedure.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
+    </element>
+    <element id="Procedure.code.coding.code">
       <path value="Procedure.code.coding.code" />
       <min value="1" />
       <fixedCode value="3950001" />

--- a/profiles/bc-BirthControl.xml
+++ b/profiles/bc-BirthControl.xml
@@ -98,9 +98,8 @@
         <comment value="ObservatieDatumTijd" />
       </mapping>
     </element>
-    <element id="Observation.value[x]:valueBoolean">
-      <path value="Observation.valueBoolean" />
-      <sliceName value="valueBoolean" />
+    <element id="Observation.value[x]">
+      <path value="Observation.value[x]" />
       <type>
         <code value="boolean" />
       </type>
@@ -163,9 +162,8 @@
         <code value="160601000146104" />
       </patternCoding>
     </element>
-    <element id="Observation.component:birthcontrolMethod.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:birthcontrolMethod.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/bc-BirthObservation.xml
+++ b/profiles/bc-BirthObservation.xml
@@ -177,15 +177,6 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="Observation.value[x].extension:valuePeriodDuration">
-      <path value="Observation.value[x].extension" />
-      <sliceName value="valuePeriodDuration" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/period-duration" />
-      </type>
-      <isModifier value="false" />
-    </element>
     <element id="Observation.value[x]:valueCodeableConcept">
       <path value="Observation.value[x]" />
       <sliceName value="valueCodeableConcept" />
@@ -256,6 +247,15 @@
         <map value="peri32-dataelement-4135" />
         <comment value="ActiefMeepersenWaarde" />
       </mapping>
+    </element>
+    <element id="Observation.value[x].extension:valuePeriodDuration">
+      <path value="Observation.value[x].extension" />
+      <sliceName value="valuePeriodDuration" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/period-duration" />
+      </type>
+      <isModifier value="false" />
     </element>
     <element id="Observation.comment">
       <path value="Observation.comment" />

--- a/profiles/bc-BreastFindings.xml
+++ b/profiles/bc-BreastFindings.xml
@@ -44,9 +44,8 @@
         <code value="116339002" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2843" />

--- a/profiles/bc-Child.xml
+++ b/profiles/bc-Child.xml
@@ -227,9 +227,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/birthPlace" />
       </type>
     </element>
-    <element id="Patient.extension:birthPlace.valueAddress:valueAddress">
-      <path value="Patient.extension.valueAddress" />
-      <sliceName value="valueAddress" />
+    <element id="Patient.extension:birthPlace.valueAddress">
+      <path value="Patient.extension.value[x]" />
       <type>
         <code value="Address" />
         <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-address" />
@@ -247,11 +246,10 @@
       <path value="Patient.extension.url" />
       <fixedUri value="http://hl7.org/fhir/StructureDefinition/patient-fetalStatus" />
     </element>
-    <element id="Patient.extension:fetalStatus.value[x]:valueCodeableConcept">
-      <path value="Patient.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Patient.extension:fetalStatus.value[x]">
+      <path value="Patient.extension.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="code" />
       </type>
       <mapping>
         <identity value="gebz-peri-v3.2" />
@@ -307,12 +305,6 @@
         <map value="peri32-dataelement-10702" />
         <comment value="Naamgebruik" />
       </mapping>
-    </element>
-    <element id="Patient.name.extension:humannameAssemblyOrder.valueCode:valueCode.value">
-      <path value="Patient.name.extension.valueCode.value" />
-      <type>
-        <code />
-      </type>
     </element>
     <element id="Patient.name.family">
       <path value="Patient.name.family" />
@@ -386,16 +378,6 @@
         <comment value="Roepnaam" />
       </mapping>
     </element>
-    <element id="Patient.name.given.extension:iso21090EnQualifier">
-      <path value="Patient.name.given.extension" />
-      <sliceName value="iso21090EnQualifier" />
-    </element>
-    <element id="Patient.name.given.extension:iso21090EnQualifier.valueCode:valueCode.value">
-      <path value="Patient.name.given.extension.valueCode.value" />
-      <type>
-        <code />
-      </type>
-    </element>
     <element id="Patient.gender">
       <path value="Patient.gender" />
       <mapping>
@@ -434,12 +416,6 @@
         </valueSetReference>
       </binding>
     </element>
-    <element id="Patient.gender.value">
-      <path value="Patient.gender.value" />
-      <type>
-        <code />
-      </type>
-    </element>
     <element id="Patient.birthDate">
       <path value="Patient.birthDate" />
       <mapping>
@@ -465,22 +441,6 @@
         <map value="peri23-dataelement-40050" />
       </mapping>
     </element>
-    <element id="Patient.birthDate.extension:birthTime.valueDateTime:valueDateTime">
-      <path value="Patient.birthDate.extension.valueDateTime" />
-      <sliceName value="valueDateTime" />
-    </element>
-    <element id="Patient.birthDate.extension:birthTime.valueDateTime:valueDateTime.value">
-      <path value="Patient.birthDate.extension.valueDateTime.value" />
-      <type>
-        <code />
-      </type>
-    </element>
-    <element id="Patient.birthDate.value">
-      <path value="Patient.birthDate.value" />
-      <type>
-        <code />
-      </type>
-    </element>
     <element id="Patient.deceased[x]">
       <path value="Patient.deceased[x]" />
       <mapping>
@@ -502,25 +462,13 @@
         <comment value="Rangnummer kind" />
       </mapping>
     </element>
-    <element id="Patient.contact.name.extension:humannameAssemblyOrder">
-      <path value="Patient.contact.name.extension" />
-      <sliceName value="humannameAssemblyOrder" />
+    <element id="Patient.communication.extension:languageProficiency">
+      <path value="Patient.communication.extension" />
+      <sliceName value="languageProficiency" />
     </element>
-    <element id="Patient.contact.name.extension:humannameAssemblyOrder.valueCode:valueCode.value">
-      <path value="Patient.contact.name.extension.valueCode.value" />
-      <type>
-        <code />
-      </type>
-    </element>
-    <element id="Patient.contact.name.given.extension:iso21090EnQualifier">
-      <path value="Patient.contact.name.given.extension" />
-      <sliceName value="iso21090EnQualifier" />
-    </element>
-    <element id="Patient.contact.name.given.extension:iso21090EnQualifier.valueCode:valueCode.value">
-      <path value="Patient.contact.name.given.extension.valueCode.value" />
-      <type>
-        <code />
-      </type>
+    <element id="Patient.communication.extension:languageProficiency.extension">
+      <path value="Patient.communication.extension.extension" />
+      <min value="2" />
     </element>
     <element id="Patient.communication.language">
       <path value="Patient.communication.language" />

--- a/profiles/bc-ChildObservation.xml
+++ b/profiles/bc-ChildObservation.xml
@@ -478,41 +478,6 @@
         </discriminator>
         <rules value="open" />
       </slicing>
-      <mapping>
-        <identity value="gebz-peri-v2.3" />
-        <map value="peri23-dataelement-10604" />
-        <comment value="Geboortegewicht" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v2.3" />
-        <map value="peri23-dataelement-40060" />
-        <comment value="Geboortegewicht" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v2.3" />
-        <map value="peri23-dataelement-70011" />
-        <comment value="Voeding kind (datum)" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v2.3" />
-        <map value="peri23-dataelement-70030" />
-        <comment value="Substantie voeding kind" />
-      </mapping>
-    </element>
-    <element id="Observation.value[x].extension:valueReference">
-      <path value="Observation.value[x].extension" />
-      <sliceName value="valueReference" />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-observation-valuereference" />
-      </type>
-      <isModifier value="false" />
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri31-dataelement-1430" />
-        <comment value="Oorzaak overlijden (Probleem)" />
-      </mapping>
     </element>
     <element id="Observation.value[x]:valueCodeableConcept">
       <path value="Observation.value[x]" />
@@ -525,6 +490,11 @@
         <description value="bc-ChildObservation-value" />
         <valueSetUri value="http://nictiz.nl/fhir/ValueSet/bc-ChildObservation-value" />
       </binding>
+      <mapping>
+        <identity value="gebz-peri-v2.3" />
+        <map value="peri23-dataelement-70030" />
+        <comment value="Substantie voeding kind" />
+      </mapping>
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-10665" />
@@ -690,6 +660,43 @@
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-10024" />
         <comment value="DatumHielprikWaarde" />
+      </mapping>
+      <mapping>
+        <identity value="gebz-peri-v2.3" />
+        <map value="peri23-dataelement-70011" />
+        <comment value="Voeding kind (datum)" />
+      </mapping>
+    </element>
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
+      <type>
+        <code value="Quantity" />
+      </type>
+      <mapping>
+        <identity value="gebz-peri-v2.3" />
+        <map value="peri23-dataelement-10604" />
+        <comment value="Geboortegewicht" />
+      </mapping>
+      <mapping>
+        <identity value="gebz-peri-v2.3" />
+        <map value="peri23-dataelement-40060" />
+        <comment value="Geboortegewicht" />
+      </mapping>
+    </element>
+    <element id="Observation.value[x].extension:valueReference">
+      <path value="Observation.value[x].extension" />
+      <sliceName value="valueReference" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-observation-valuereference" />
+      </type>
+      <isModifier value="false" />
+      <mapping>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri31-dataelement-1430" />
+        <comment value="Oorzaak overlijden (Probleem)" />
       </mapping>
     </element>
     <element id="Observation.comment">
@@ -1032,20 +1039,6 @@
         <map value="peri32-dataelement-8732" />
         <comment value="ObservatieSpecimen" />
       </mapping>
-    </element>
-    <element id="Observation.component">
-      <path value="Observation.component" />
-      <slicing>
-        <discriminator>
-          <type value="pattern" />
-          <path value="code" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.component:clothing">
-      <path value="Observation.component" />
-      <sliceName value="clothing" />
     </element>
   </differential>
 </StructureDefinition>

--- a/profiles/bc-ClinicalImpression.xml
+++ b/profiles/bc-ClinicalImpression.xml
@@ -155,9 +155,6 @@
         <comment value="ConclusieDatumTijd" />
       </mapping>
     </element>
-    <element id="ClinicalImpression.effective[x]:effectiveDateTime.value">
-      <path value="ClinicalImpression.effective[x].value" />
-    </element>
     <element id="ClinicalImpression.assessor">
       <path value="ClinicalImpression.assessor" />
       <type>
@@ -238,9 +235,8 @@
       <sliceName value="pregnancyRiskCategory" />
       <max value="1" />
     </element>
-    <element id="ClinicalImpression.finding:pregnancyRiskCategory.item[x]:itemCodeableConcept">
-      <path value="ClinicalImpression.finding.itemCodeableConcept" />
-      <sliceName value="itemCodeableConcept" />
+    <element id="ClinicalImpression.finding:pregnancyRiskCategory.item[x]">
+      <path value="ClinicalImpression.finding.item[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/bc-DeliveryObservation.xml
+++ b/profiles/bc-DeliveryObservation.xml
@@ -161,9 +161,8 @@
         <comment value="Eerdere bevalling" />
       </mapping>
     </element>
-    <element id="Observation.extension:delivery.valueReference:valueReference">
+    <element id="Observation.extension:delivery.valueReference">
       <path value="Observation.extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryProcedure" />
@@ -338,15 +337,6 @@
         <comment value="Risicostatus voor baring" />
       </mapping>
     </element>
-    <element id="Observation.value[x].extension:valuePeriodDuration">
-      <path value="Observation.value[x].extension" />
-      <sliceName value="valuePeriodDuration" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/period-duration" />
-      </type>
-      <isModifier value="false" />
-    </element>
     <element id="Observation.value[x]:valueQuantity">
       <path value="Observation.value[x]" />
       <sliceName value="valueQuantity" />
@@ -441,6 +431,15 @@
         <map value="peri32-dataelement-4269" />
         <comment value="TestuitslagPAWaarde" />
       </mapping>
+    </element>
+    <element id="Observation.value[x].extension:valuePeriodDuration">
+      <path value="Observation.value[x].extension" />
+      <sliceName value="valuePeriodDuration" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/period-duration" />
+      </type>
+      <isModifier value="false" />
     </element>
     <element id="Observation.comment">
       <path value="Observation.comment" />

--- a/profiles/bc-DeliveryProcedure.xml
+++ b/profiles/bc-DeliveryProcedure.xml
@@ -139,13 +139,16 @@
         <display value="Obstetric procedure (procedure)" />
       </patternCoding>
     </element>
-    <element id="Procedure.code.coding:delivery">
+    <element id="Procedure.code.coding">
       <path value="Procedure.code.coding" />
-      <sliceName value="delivery" />
       <min value="1" />
       <max value="1" />
     </element>
-    <element id="Procedure.code.coding:delivery.code">
+    <element id="Procedure.code.coding.system">
+      <path value="Procedure.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
+    </element>
+    <element id="Procedure.code.coding.code">
       <path value="Procedure.code.coding.code" />
       <min value="1" />
       <fixedCode value="236973005" />

--- a/profiles/bc-DisorderOfChild.xml
+++ b/profiles/bc-DisorderOfChild.xml
@@ -252,6 +252,11 @@
         <map value="peri32-dataelement-10650" />
         <comment value="Probleem (Extremiteiten)" />
       </mapping>
+      <mapping>
+        <identity value="gebz-peri-v3.2"/>
+        <map value="peri32-dataelement-10682"/>
+        <comment value="Probleem (OpnameIndicatie_LNR)"/>
+      </mapping>
     </element>
     <element id="Condition.extension:onsetInstitution">
       <path value="Condition.extension" />

--- a/profiles/bc-DisorderOfChild.xml
+++ b/profiles/bc-DisorderOfChild.xml
@@ -253,9 +253,9 @@
         <comment value="Probleem (Extremiteiten)" />
       </mapping>
       <mapping>
-        <identity value="gebz-peri-v3.2"/>
-        <map value="peri32-dataelement-10682"/>
-        <comment value="Probleem (OpnameIndicatie_LNR)"/>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri32-dataelement-10682" />
+        <comment value="Probleem (OpnameIndicatie_LNR)" />
       </mapping>
     </element>
     <element id="Condition.extension:onsetInstitution">
@@ -944,9 +944,8 @@
       <path value="Condition.bodySite.extension" />
       <sliceName value="Laterality" />
     </element>
-    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept:valueCodeableConcept">
+    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept">
       <path value="Condition.bodySite.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-10684" />
@@ -1051,9 +1050,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/body-site-instance" />
       </type>
     </element>
-    <element id="Condition.bodySite.extension:bodySiteReference.valueReference:valueReference">
-      <path value="Condition.bodySite.extension.valueReference" />
-      <sliceName value="valueReference" />
+    <element id="Condition.bodySite.extension:bodySiteReference.valueReference">
+      <path value="Condition.bodySite.extension.value[x]" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite" />

--- a/profiles/bc-DisorderOfLaborAndDelivery.xml
+++ b/profiles/bc-DisorderOfLaborAndDelivery.xml
@@ -92,9 +92,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/condition-partOf" />
       </type>
     </element>
-    <element id="Condition.extension:delivery.value[x]:valueReference">
+    <element id="Condition.extension:delivery.value[x]">
       <path value="Condition.extension.value[x]" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/bc-Birth" />
@@ -233,9 +232,8 @@
       <path value="Condition.bodySite.extension" />
       <sliceName value="Laterality" />
     </element>
-    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept:valueCodeableConcept">
+    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept">
       <path value="Condition.bodySite.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-1593" />
@@ -250,9 +248,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/body-site-instance" />
       </type>
     </element>
-    <element id="Condition.bodySite.extension:bodySiteReference.valueReference:valueReference">
-      <path value="Condition.bodySite.extension.valueReference" />
-      <sliceName value="valueReference" />
+    <element id="Condition.bodySite.extension:bodySiteReference.valueReference">
+      <path value="Condition.bodySite.extension.value[x]" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite" />
@@ -304,6 +301,12 @@
         <comment value="ProbleemBeginDatum" />
       </mapping>
     </element>
+    <element id="Condition.onsetDateTime:onsetDateTime.value">
+      <path value="Condition.onsetDateTime.value" />
+      <type>
+        <code />
+      </type>
+    </element>
     <element id="Condition.abatementDateTime:abatementDateTime">
       <path value="Condition.abatementDateTime" />
       <sliceName value="abatementDateTime" />
@@ -317,6 +320,12 @@
         <map value="peri32-dataelement-1597" />
         <comment value="ProbleemEindDatum" />
       </mapping>
+    </element>
+    <element id="Condition.abatementDateTime:abatementDateTime.value">
+      <path value="Condition.abatementDateTime.value" />
+      <type>
+        <code />
+      </type>
     </element>
     <element id="Condition.assertedDate">
       <path value="Condition.assertedDate" />

--- a/profiles/bc-DisorderOfPregnancy.xml
+++ b/profiles/bc-DisorderOfPregnancy.xml
@@ -255,9 +255,8 @@
       <path value="Condition.bodySite.extension" />
       <sliceName value="Laterality" />
     </element>
-    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept:valueCodeableConcept">
+    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept">
       <path value="Condition.bodySite.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-1182" />
@@ -277,9 +276,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/body-site-instance" />
       </type>
     </element>
-    <element id="Condition.bodySite.extension:bodySiteReference.valueReference:valueReference">
-      <path value="Condition.bodySite.extension.valueReference" />
-      <sliceName value="valueReference" />
+    <element id="Condition.bodySite.extension:bodySiteReference.valueReference">
+      <path value="Condition.bodySite.extension.value[x]" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite" />
@@ -331,6 +329,12 @@
         <comment value="ProbleemBeginDatum" />
       </mapping>
     </element>
+    <element id="Condition.onsetDateTime:onsetDateTime.value">
+      <path value="Condition.onsetDateTime.value" />
+      <type>
+        <code />
+      </type>
+    </element>
     <element id="Condition.abatementDateTime:abatementDateTime">
       <path value="Condition.abatementDateTime" />
       <sliceName value="abatementDateTime" />
@@ -344,6 +348,12 @@
         <map value="peri32-dataelement-2466" />
         <comment value="ProbleemEindDatum" />
       </mapping>
+    </element>
+    <element id="Condition.abatementDateTime:abatementDateTime.value">
+      <path value="Condition.abatementDateTime.value" />
+      <type>
+        <code />
+      </type>
     </element>
     <element id="Condition.evidence.code">
       <path value="Condition.evidence.code" />

--- a/profiles/bc-DisorderPostPartum.xml
+++ b/profiles/bc-DisorderPostPartum.xml
@@ -72,11 +72,6 @@
         <map value="peri32-dataelement-3833" />
         <comment value="Probleem (Postpartum complicatie)" />
       </mapping>
-      <!--<mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-9144" />
-        <comment value="Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)" />
-      </mapping>-->
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-9661" />
@@ -117,9 +112,8 @@
         <comment value="Eerdere bevalling" />
       </mapping>
     </element>
-    <element id="Condition.extension:delivery.value[x]:valueReference">
+    <element id="Condition.extension:delivery.value[x]">
       <path value="Condition.extension.valueReference" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/bc-DeliveryProcedure" />
@@ -239,9 +233,8 @@
       <path value="Condition.bodySite.extension" />
       <sliceName value="Laterality" />
     </element>
-    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept:valueCodeableConcept">
+    <element id="Condition.bodySite.extension:Laterality.valueCodeableConcept">
       <path value="Condition.bodySite.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2307" />
@@ -261,9 +254,8 @@
         <profile value="http://hl7.org/fhir/StructureDefinition/body-site-instance" />
       </type>
     </element>
-    <element id="Condition.bodySite.extension:bodySiteReference.valueReference:valueReference">
-      <path value="Condition.bodySite.extension.valueReference" />
-      <sliceName value="valueReference" />
+    <element id="Condition.bodySite.extension:bodySiteReference.valueReference">
+      <path value="Condition.bodySite.extension.value[x]" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodySite" />

--- a/profiles/bc-Encounter.xml
+++ b/profiles/bc-Encounter.xml
@@ -246,9 +246,8 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-encounter-reasonreference" />
       </type>
     </element>
-    <element id="Encounter.reason.extension:reasonReference.value[x]:valueReference">
+    <element id="Encounter.reason.extension:reasonReference.value[x]">
       <path value="Encounter.reason.extension.value[x]" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
       </type>

--- a/profiles/bc-ExcretionFeces.xml
+++ b/profiles/bc-ExcretionFeces.xml
@@ -49,9 +49,8 @@
         <code value="249612005" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2-ext" />
         <map value="peri32-dataelement-9938" />
@@ -61,10 +60,6 @@
     <element id="Observation.value[x]:valueDateTime">
       <path value="Observation.value[x]" />
       <sliceName value="valueDateTime" />
-    </element>
-    <element id="Observation.value[x]:valueDateTime.value">
-      <path value="Observation.value[x].value" />
-      <type />
     </element>
     <element id="Observation.comment">
       <path value="Observation.comment" />
@@ -97,10 +92,15 @@
         <comment value="ObservatieSpecimen" />
       </mapping>
     </element>
-    <element id="Observation.component:clothing">
-      <path value="Observation.component" />
-      <sliceName value="clothing" />
-      <max value="0" />
+    <element id="Observation.component">
+      <path value="Observation.component"/>
+      <slicing>
+        <discriminator>
+          <type value="pattern"/>
+          <path value="code.coding"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
     </element>
     <element id="Observation.component:feces">
       <path value="Observation.component" />
@@ -116,9 +116,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:feces.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:feces.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -149,9 +148,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:fecalDiapers.value[x]:valueQuantity">
-      <path value="Observation.component.valueQuantity" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:fecalDiapers.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="Quantity" />
       </type>

--- a/profiles/bc-ExcretionUrine.xml
+++ b/profiles/bc-ExcretionUrine.xml
@@ -49,9 +49,8 @@
         <code value="301830001" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2-ext" />
         <map value="peri32-dataelement-9948" />
@@ -89,10 +88,15 @@
         <comment value="ObservatieSpecimen" />
       </mapping>
     </element>
-    <element id="Observation.component:clothing">
-      <path value="Observation.component" />
-      <sliceName value="clothing" />
-      <max value="0" />
+    <element id="Observation.component">
+      <path value="Observation.component"/>
+      <slicing>
+        <discriminator>
+          <type value="pattern"/>
+          <path value="code.coding"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
     </element>
     <element id="Observation.component:urine">
       <path value="Observation.component" />
@@ -108,9 +112,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:urine.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:urine.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -137,9 +140,8 @@
         <code value="160291000146107" />
       </patternCoding>
     </element>
-    <element id="Observation.component:urineDiapers.value[x]:valueQuantity">
-      <path value="Observation.component.valueQuantity" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:urineDiapers.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="Quantity" />
       </type>

--- a/profiles/bc-FamilySituationAssessment.xml
+++ b/profiles/bc-FamilySituationAssessment.xml
@@ -44,9 +44,8 @@
         <code value="423340009" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2915" />
@@ -93,9 +92,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:unstableFamilySituation.value[x]:valueString">
-      <path value="Observation.component.valueString" />
-      <sliceName value="valueString" />
+    <element id="Observation.component:unstableFamilySituation.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="string" />
       </type>
@@ -118,8 +116,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:alarmingFamilySituation.value[x]:valueString">
-      <path value="Observation.component.valueString" />
+    <element id="Observation.component:alarmingFamilySituation.value[x]">
+      <path value="Observation.component.value[x]" />
       <sliceName value="valueString" />
       <type>
         <code value="string" />
@@ -143,9 +141,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:intoxication.value[x]:valueString">
-      <path value="Observation.component.valueString" />
-      <sliceName value="valueString" />
+    <element id="Observation.component:intoxication.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="string" />
       </type>

--- a/profiles/bc-FeedingPatternInfant.xml
+++ b/profiles/bc-FeedingPatternInfant.xml
@@ -75,9 +75,11 @@
       <path value="Observation.component" />
       <sliceName value="FeedingSupplement" />
     </element>
-    <element id="Observation.component:FeedingSupplement.valueString:valueString">
-      <path value="Observation.component.valueString" />
-      <sliceName value="valueString" />
+    <element id="Observation.component:FeedingSupplement.value[x]">
+      <path value="Observation.component.value[x]" />
+      <type>
+        <code value="string" />
+      </type>
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-7939" />
@@ -88,9 +90,11 @@
       <path value="Observation.component" />
       <sliceName value="FeedingFrequency" />
     </element>
-    <element id="Observation.component:FeedingFrequency.valueQuantity:valueQuantity">
-      <path value="Observation.component.valueQuantity" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:FeedingFrequency.value[x]">
+      <path value="Observation.component.value[x]" />
+      <type>
+        <code value="Quantity" />
+      </type>
       <example>
         <label value="Example of frequency" />
         <valueQuantity>
@@ -154,9 +158,11 @@
         <comment value="VoedingDuur" />
       </mapping>
     </element>
-    <element id="Observation.component:FeedingType.valueCodeableConcept:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:FeedingType.value[x]">
+      <path value="Observation.component.value[x]" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
       <binding>
         <strength value="extensible" />
         <description value="VoedingSoort_GZ" />
@@ -184,9 +190,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:SupplementaryFeeding.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:SupplementaryFeeding.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/bc-FetalHeartRate.xml
+++ b/profiles/bc-FetalHeartRate.xml
@@ -117,9 +117,8 @@
         <comment value="Zorgverlening" />
       </mapping>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-1778" />
@@ -131,9 +130,8 @@
         <comment value="HartfrequentieDatumTijd" />
       </mapping>
     </element>
-    <element id="Observation.value[x]:valueQuantity">
+    <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
-      <sliceName value="valueQuantity" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-1777" />
@@ -244,9 +242,8 @@
         <code value="249044008" />
       </patternCoding>
     </element>
-    <element id="Observation.component:heartRateRegularity.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:heartRateRegularity.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/bc-FetalMonitoring.xml
+++ b/profiles/bc-FetalMonitoring.xml
@@ -49,9 +49,8 @@
         <code value="281568006" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectivePeriod">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectivePeriod" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-1768" />
@@ -62,6 +61,10 @@
         <map value="peri32-dataelement-11025" />
         <comment value="TijdsInterval" />
       </mapping>
+    </element>
+    <element id="Observation.effective[x]:effectiveDateTime">
+      <path value="Observation.effective[x]" />
+      <sliceName value="effectiveDateTime" />
     </element>
     <element id="Observation.performer">
       <path value="Observation.performer" />
@@ -139,16 +142,6 @@
         <comment value="EffectOpFoetaleHartslag" />
       </mapping>
     </element>
-    <element id="Observation.component">
-      <path value="Observation.component" />
-      <slicing>
-        <discriminator>
-          <type value="pattern" />
-          <path value="code" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
     <element id="Observation.component:monitoringMoment">
       <path value="Observation.component" />
       <sliceName value="monitoringMoment" />
@@ -161,9 +154,8 @@
         <code value="160201000146101" />
       </patternCoding>
     </element>
-    <element id="Observation.component:monitoringMoment.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:monitoringMoment.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -191,9 +183,8 @@
         <code value="251670001" />
       </patternCoding>
     </element>
-    <element id="Observation.component:basalHeartRate.value[x]:valueQuantity">
-      <path value="Observation.component.valueQuantity" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:basalHeartRate.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="Quantity" />
       </type>
@@ -203,12 +194,12 @@
         <comment value="BasisHartFrequentie" />
       </mapping>
     </element>
-    <element id="Observation.component:basalHeartRate.value[x]:valueQuantity.unit">
-      <path value="Observation.component.valueQuantity.unit" />
+    <element id="Observation.component:basalHeartRate.value[x].unit">
+      <path value="Observation.component.value[x].unit" />
       <defaultValueString value="min" />
     </element>
-    <element id="Observation.component:basalHeartRate.value[x]:valueQuantity.code">
-      <path value="Observation.component.valueQuantity.code" />
+    <element id="Observation.component:basalHeartRate.value[x].code">
+      <path value="Observation.component.value[x].code" />
       <defaultValueCode value="min" />
     </element>
     <element id="Observation.component:fetalAccelerations">
@@ -223,9 +214,8 @@
         <code value="251676007" />
       </patternCoding>
     </element>
-    <element id="Observation.component:fetalAccelerations.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:fetalAccelerations.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -252,9 +242,8 @@
         <code value="251673004" />
       </patternCoding>
     </element>
-    <element id="Observation.component:fetalDecelerations.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:fetalDecelerations.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -281,9 +270,8 @@
         <code value="251671002" />
       </patternCoding>
     </element>
-    <element id="Observation.component:heartFrequencyVariability.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:heartFrequencyVariability.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -312,9 +300,8 @@
         <code value="160211000146104" />
       </patternCoding>
     </element>
-    <element id="Observation.component:conclusionFIGO.value[x]:valueCodeableConcept">
-      <path value="Observation.component.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
+    <element id="Observation.component:conclusionFIGO.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -343,9 +330,8 @@
         <code value="160221000146109" />
       </patternCoding>
     </element>
-    <element id="Observation.component:conclusionFisher.value[x]:valueQuantity">
-      <path value="Observation.component.valueQuantity" />
-      <sliceName value="valueQuantity" />
+    <element id="Observation.component:conclusionFisher.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="Quantity" />
       </type>
@@ -355,12 +341,12 @@
         <comment value="ConclusieFisher" />
       </mapping>
     </element>
-    <element id="Observation.component:conclusionFisher.value[x]:valueQuantity.system">
-      <path value="Observation.component.valueQuantity.system" />
+    <element id="Observation.component:conclusionFisher.value[x].system">
+      <path value="Observation.component.value[x].system" />
       <fixedUri value="http://unitsofmeasure.org" />
     </element>
-    <element id="Observation.component:conclusionFisher.value[x]:valueQuantity.code">
-      <path value="Observation.component.valueQuantity.code" />
+    <element id="Observation.component:conclusionFisher.value[x].code">
+      <path value="Observation.component.value[x].code" />
       <fixedCode value="1" />
     </element>
   </differential>

--- a/profiles/bc-FetusObservation.xml
+++ b/profiles/bc-FetusObservation.xml
@@ -345,12 +345,6 @@
         <comment value="ObservatieDatumTijd" />
       </mapping>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime.value">
-      <path value="Observation.effective[x].value" />
-      <type>
-        <code />
-      </type>
-    </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
       <slicing>

--- a/profiles/bc-IndividualCarePlan-Goal.xml
+++ b/profiles/bc-IndividualCarePlan-Goal.xml
@@ -63,12 +63,6 @@
         <comment value="StreefDatum" />
       </mapping>
     </element>
-    <element id="Goal.target.due[x]:dueDate.value">
-      <path value="Goal.target.dueDate.value" />
-      <type>
-        <code />
-      </type>
-    </element>
     <element id="Goal.statusDate">
       <path value="Goal.statusDate" />
       <comment value="To see the date for past statuses, query history. For example, for the determination date, look at status = proposed." />

--- a/profiles/bc-LegalSituation-LegalStatus.xml
+++ b/profiles/bc-LegalSituation-LegalStatus.xml
@@ -107,9 +107,8 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/bc-Child" />
       </type>
     </element>
-    <element id="Condition.onset[x]:onsetDateTime">
+    <element id="Condition.onset[x]">
       <path value="Condition.onset[x]" />
-      <sliceName value="onsetDateTime" />
       <type>
         <code value="dateTime" />
       </type>
@@ -124,15 +123,8 @@
         <comment value="DatumAanvang" />
       </mapping>
     </element>
-    <element id="Condition.onset[x]:onsetDateTime.value">
-      <path value="Condition.onset[x].value" />
-      <type>
-        <code />
-      </type>
-    </element>
-    <element id="Condition.abatement[x]:abatementDateTime">
+    <element id="Condition.abatement[x]">
       <path value="Condition.abatement[x]" />
-      <sliceName value="abatementDateTime" />
       <type>
         <code value="dateTime" />
       </type>
@@ -146,12 +138,6 @@
         <map value="peri32-dataelement-7862" />
         <comment value="DatumEinde" />
       </mapping>
-    </element>
-    <element id="Condition.abatement[x]:abatementDateTime.value">
-      <path value="Condition.abatement[x].value" />
-      <type>
-        <code />
-      </type>
     </element>
   </differential>
 </StructureDefinition>

--- a/profiles/bc-LegalSituation-Representation.xml
+++ b/profiles/bc-LegalSituation-Representation.xml
@@ -96,9 +96,8 @@
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/bc-Child" />
       </type>
     </element>
-    <element id="Condition.onset[x]:onsetDateTime">
+    <element id="Condition.onset[x]">
       <path value="Condition.onset[x]" />
-      <sliceName value="onsetDateTime" />
       <type>
         <code value="dateTime" />
       </type>
@@ -108,15 +107,8 @@
         <comment value="DatumAanvang" />
       </mapping>
     </element>
-    <element id="Condition.onset[x]:onsetDateTime.value">
-      <path value="Condition.onset[x].value" />
-      <type>
-        <code />
-      </type>
-    </element>
-    <element id="Condition.abatement[x]:abatementDateTime">
+    <element id="Condition.abatement[x]">
       <path value="Condition.abatement[x]" />
-      <sliceName value="abatementDateTime" />
       <type>
         <code value="dateTime" />
       </type>
@@ -125,12 +117,6 @@
         <map value="peri32-dataelement-7862" />
         <comment value="DatumEinde" />
       </mapping>
-    </element>
-    <element id="Condition.abatement[x]:abatementDateTime.value">
-      <path value="Condition.abatement[x].value" />
-      <type>
-        <code />
-      </type>
     </element>
   </differential>
 </StructureDefinition>

--- a/profiles/bc-MaternalObservation.xml
+++ b/profiles/bc-MaternalObservation.xml
@@ -441,12 +441,6 @@
         <comment value="ObservatieDatumTijd" />
       </mapping>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime.value">
-      <path value="Observation.effective[x].value" />
-      <type>
-        <code />
-      </type>
-    </element>
     <element id="Observation.effective[x]:effectivePeriod">
       <path value="Observation.effective[x]" />
       <sliceName value="effectivePeriod" />
@@ -795,26 +789,6 @@
         <comment value="Conclusie risicostatus na intake" />
       </mapping>
     </element>
-    <element id="Observation.value[x].extension:valueReference">
-      <path value="Observation.value[x].extension" />
-      <sliceName value="valueReference" />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-observation-valuereference" />
-      </type>
-      <isModifier value="false" />
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2270" />
-        <comment value="Zorgaanbieder" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2938" />
-        <comment value="Voorkeursziekenhuis" />
-      </mapping>
-    </element>
     <element id="Observation.value[x]:valueCodeableConcept">
       <path value="Observation.value[x]" />
       <sliceName value="valueCodeableConcept" />
@@ -1100,6 +1074,26 @@
         <comment value="WenstVrouwMinderKraamzorgDatumTijd" />
       </mapping>
     </element>
+    <element id="Observation.value[x].extension:bcObservationValueReference">
+      <path value="Observation.value[x].extension" />
+      <sliceName value="bcObservationValueReference" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-observation-valuereference" />
+      </type>
+      <isModifier value="false" />
+      <mapping>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri32-dataelement-2270" />
+        <comment value="Zorgaanbieder" />
+      </mapping>
+      <mapping>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri32-dataelement-2938" />
+        <comment value="Voorkeursziekenhuis" />
+      </mapping>
+    </element>
     <element id="Observation.comment">
       <path value="Observation.comment" />
       <mapping>
@@ -1273,9 +1267,9 @@
         <comment value="Toelichting" />
       </mapping>
       <mapping>
-        <identity value="gebz-peri-v3.2"/>
-        <map value="peri32-dataelement-9180"/>
-        <comment value="Toelichting"/>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri32-dataelement-9180" />
+        <comment value="Toelichting" />
       </mapping>
     </element>
     <element id="Observation.bodySite">

--- a/profiles/bc-MaternalObservation.xml
+++ b/profiles/bc-MaternalObservation.xml
@@ -108,11 +108,6 @@
       </mapping>
       <mapping>
         <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-1846" />
-        <comment value="Maternale sterfte" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-3635" />
         <comment value="Cervixlengte (Meting)" />
       </mapping>
@@ -273,8 +268,18 @@
       </mapping>
       <mapping>
         <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-3113" />
-        <comment value="Aantal kraamverbanden" />
+        <map value="peri32-dataelement-2252" />
+        <comment value="Voorgenomen plaats baring tijdens zwangerschap (Observatie)" />
+      </mapping>
+      <mapping>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri32-dataelement-2272" />
+        <comment value="Voorgenomen achternaam (Observatie)" />
+      </mapping>
+      <mapping>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri32-dataelement-2269" />
+        <comment value="Kraamzorg aangevraagd (Observatie)" />
       </mapping>
     </element>
     <element id="Observation.code">
@@ -828,11 +833,6 @@
       </mapping>
       <mapping>
         <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2252" />
-        <comment value="Voorgenomen plaats baring tijdens zwangerschap (Observatie)" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2255" />
         <comment value="VoorgenomenPlaatsBaringWaarde" />
       </mapping>
@@ -1007,11 +1007,6 @@
       </mapping>
       <mapping>
         <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2269" />
-        <comment value="Kraamzorg aangevraagd (Observatie)" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2277" />
         <comment value="KraamzorgAangevraagdWaarde" />
       </mapping>
@@ -1072,11 +1067,6 @@
       <type>
         <code value="string" />
       </type>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2272" />
-        <comment value="Voorgenomen achternaam (Observatie)" />
-      </mapping>
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2275" />

--- a/profiles/bc-MultidisciplinaryTeamMeeting-Plan.xml
+++ b/profiles/bc-MultidisciplinaryTeamMeeting-Plan.xml
@@ -74,8 +74,8 @@
       <path value="CarePlan.category" />
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="$this" />
+          <type value="pattern" />
+          <path value="coding" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/profiles/bc-ObstetricProcedure.xml
+++ b/profiles/bc-ObstetricProcedure.xml
@@ -570,12 +570,6 @@
         <code value="dateTime" />
       </type>
     </element>
-    <element id="Procedure.performed[x]:performedDateTime.value">
-      <path value="Procedure.performed[x].value" />
-      <type>
-        <code />
-      </type>
-    </element>
     <element id="Procedure.performer">
       <path value="Procedure.performer" />
       <mapping>
@@ -862,9 +856,8 @@
         <comment value="VerrichtingLateraliteit" />
       </mapping>
     </element>
-    <element id="Procedure.bodySite.extension:ProcedureLaterality.valueCodeableConcept:valueCodeableConcept">
+    <element id="Procedure.bodySite.extension:ProcedureLaterality.valueCodeableConcept">
       <path value="Procedure.bodySite.extension.valueCodeableConcept" />
-      <sliceName value="valueCodeableConcept" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-1194" />

--- a/profiles/bc-PerinatalDeath.xml
+++ b/profiles/bc-PerinatalDeath.xml
@@ -97,9 +97,11 @@
         <comment value="Zorgverlening" />
       </mapping>
     </element>
-    <element id="Observation.value[x]:valueBoolean">
+    <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
-      <sliceName value="valueBoolean" />
+      <type>
+        <code value="boolean" />
+      </type>
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-10551" />
@@ -136,9 +138,8 @@
         <code value="399753006" />
       </patternCoding>
     </element>
-    <element id="Observation.component:deceasedDateTime.value[x]:valueDateTime">
-      <path value="Observation.component.valueDateTime" />
-      <sliceName value="valueDateTime" />
+    <element id="Observation.component:deceasedDateTime.value[x]">
+      <path value="Observation.component.value[x]" />
       <type>
         <code value="dateTime" />
       </type>
@@ -160,9 +161,8 @@
         <code value="246454002" />
       </patternCoding>
     </element>
-    <element id="Observation.component:perinatalPhase.value[x]:valueCodeableConcept">
+    <element id="Observation.component:perinatalPhase.value[x]">
       <path value="Observation.component.value[x]" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -172,7 +172,7 @@
         <comment value="FasePerinataleSterfteWaarde" />
       </mapping>
     </element>
-    <element id="Observation.component:perinatalPhase.value[x]:valueCodeableConcept.coding">
+    <element id="Observation.component:perinatalPhase.value[x].coding">
       <path value="Observation.component.value[x].coding" />
       <binding>
         <strength value="extensible" />

--- a/profiles/bc-PerinealAssessment.xml
+++ b/profiles/bc-PerinealAssessment.xml
@@ -37,9 +37,8 @@
         <comment value="Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)" />
       </mapping>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-3952" />

--- a/profiles/bc-PlacentaLocalization.xml
+++ b/profiles/bc-PlacentaLocalization.xml
@@ -45,9 +45,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2438" />

--- a/profiles/bc-PregnancyObservation.xml
+++ b/profiles/bc-PregnancyObservation.xml
@@ -345,11 +345,6 @@
       </type>
       <mapping>
         <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-1847" />
-        <comment value="OverlijdensIndicator" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-4160" />
         <comment value="TOPnavPrenataalOnderzoekWaarde" />
       </mapping>
@@ -374,11 +369,6 @@
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-2223" />
         <comment value="Definitieve a terme Waarde" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-1848" />
-        <comment value="DatumOverlijden" />
       </mapping>
     </element>
     <element id="Observation.comment">

--- a/profiles/bc-PregnancyObservation.xml
+++ b/profiles/bc-PregnancyObservation.xml
@@ -166,9 +166,8 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <type>
         <code value="dateTime" />
       </type>

--- a/profiles/bc-PregnancyUltraSoundGeneralFindings.xml
+++ b/profiles/bc-PregnancyUltraSoundGeneralFindings.xml
@@ -44,9 +44,8 @@
       <path value="Observation.code.coding.code" />
       <patternCode value="290201000146101" />
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-8919" />

--- a/profiles/bc-TreatmentDirective.xml
+++ b/profiles/bc-TreatmentDirective.xml
@@ -91,9 +91,8 @@
       </type>
       <condition value="zib-TreatmentDirective2-1" />
     </element>
-    <element id="Consent.extension:additionalAdvanceDirective.value[x]:valueReference">
+    <element id="Consent.extension:additionalAdvanceDirective.value[x]">
       <path value="Consent.extension.value[x]" />
-      <sliceName value="valueReference" />
       <type>
         <code value="Reference" />
       </type>
@@ -109,9 +108,8 @@
       <condition value="zib-TreatmentDirective2-2" />
       <mustSupport value="true" />
     </element>
-    <element id="Consent.modifierExtension:specificationOther.value[x]:valueString">
+    <element id="Consent.modifierExtension:specificationOther.value[x]">
       <path value="Consent.modifierExtension.value[x]" />
-      <sliceName value="valueString" />
       <condition value="zib-TreatmentDirective2-2" />
       <mapping>
         <identity value="gebz-peri-v3.2" />

--- a/profiles/bc-UmbilicalCord.xml
+++ b/profiles/bc-UmbilicalCord.xml
@@ -96,18 +96,16 @@
         <comment value="Zorgverlening" />
       </mapping>
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-7791" />
         <comment value="NavelstrengDatumTijd" />
       </mapping>
     </element>
-    <element id="Observation.value[x]:valueCodeableConcept">
+    <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
-      <sliceName value="valueCodeableConcept" />
       <binding>
         <strength value="extensible" />
         <description value="BeoordelingBevindingen" />
@@ -161,9 +159,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:umbilicalCordVessels.value[x]:valueCodeableConcept">
+    <element id="Observation.component:umbilicalCordVessels.value[x]">
       <path value="Observation.component.value[x]" />
-      <sliceName value="valueCodeableConcept" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/profiles/bc-UterusActivity.xml
+++ b/profiles/bc-UterusActivity.xml
@@ -49,9 +49,8 @@
         <code value="364277008" />
       </patternCoding>
     </element>
-    <element id="Observation.effective[x]:effectivePeriod">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectivePeriod" />
       <type>
         <code value="Period" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/bc-TimeInterval" />

--- a/profiles/bc-VitaminKAdministration.xml
+++ b/profiles/bc-VitaminKAdministration.xml
@@ -55,9 +55,8 @@
       <path value="Observation.code.coding.code" />
       <patternCode value="698350008" />
     </element>
-    <element id="Observation.effective[x]:effectiveDateTime">
+    <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
-      <sliceName value="effectiveDateTime" />
       <mapping>
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-10762" />
@@ -93,6 +92,16 @@
         <comment value="ObservatieMethode" />
       </mapping>
     </element>
+    <element id="Observation.component">
+      <path value="Observation.component" />
+      <slicing>
+        <discriminator>
+          <type value="pattern" />
+          <path value="code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
     <element id="Observation.component:administrationDate">
       <path value="Observation.component" />
       <sliceName value="administrationDate" />
@@ -107,9 +116,8 @@
         </coding>
       </patternCodeableConcept>
     </element>
-    <element id="Observation.component:administrationDate.value[x]:valueDateTime">
+    <element id="Observation.component:administrationDate.value[x]">
       <path value="Observation.component.value[x]" />
-      <sliceName value="valueDateTime" />
       <type>
         <code value="dateTime" />
       </type>
@@ -119,5 +127,5 @@
         <comment value="DatumVitamineKWaarde" />
       </mapping>
     </element>
-  </differential>
+    </differential>
 </StructureDefinition>

--- a/wikigen/scripts/fhirmapping-2-valueset.cmd
+++ b/wikigen/scripts/fhirmapping-2-valueset.cmd
@@ -1,0 +1,3 @@
+java -jar "%~dp0../../../YATC-tools/saxon/saxon.jar" -xsl:"%~dp0fhirmapping-2-valueset.xsl" "%~dp0../../fhirmapping-3-2.xml" outputdir=%~dp0
+
+

--- a/wikigen/scripts/fhirmapping-2-valueset.log
+++ b/wikigen/scripts/fhirmapping-2-valueset.log
@@ -1,0 +1,132 @@
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-BirthObservation-code.xml ...
+bc-BirthObservation-code WARNING: NOT including Code 289251005 - tijdstip waarop gebroken vliezen zijn geconstateerd (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-4111 BrekenVliezenWaarde in a different profile "bc-DeliveryObservation"
+bc-BirthObservation-code WARNING: NOT including Code 386639001 - afbreken van zwangerschap (verrichting) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-1197 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-1554 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-4147 TypePartusWaarde in profile "bc-BirthObservation"
+    peri31-dataelement-1456 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-1536 VerrichtingType in profile ""
+bc-BirthObservation-code WARNING: NOT including Code 271692001 - presenterend deel van foetus (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-4172 LiggingKindWaarde in a different profile "bc-FetusObservation"
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-ChildObservation-code.xml ...
+bc-ChildObservation-code WARNING: NOT including Code 442618008 413083006 - afwijkende bevinding tijdens evaluatie (bevinding) automated auditory brainstem response test (verrichting) - http://snomed.info/sct
+    Concept(s):    | not found in transactions |
+bc-ChildObservation-code WARNING: NOT including Code 105421008 - opleidingsniveau (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-2582 Schooltype in a different profile "bc-MaternalObservation"
+bc-ChildObservation-code WARNING: NOT including Code 8339-4 - Birth weight Measured - http://loinc.org
+    Concept(s):
+    peri32-dataelement-1419 GewichtWaarde in a different profile "zib-BodyWeight"
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-DeliveryObservation-code.xml ...
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-DisorderOfChild-code.xml ...
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.90.77.11.231--20220120134819
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.5.1.3--20171231000000
+    Concept(s):
+    peri32-dataelement-2539 ProbleemNaam in a different profile "zib-Problem"
+    peri32-dataelement-8827 ProbleemNaam in a different profile "zib-Problem"
+    peri32-dataelement-2309 ProbleemNaam in a different profile "bc-DisorderPostPartum"
+    peri32-dataelement-8837 ProbleemNaam in a different profile "zib-Problem"
+    peri32-dataelement-8847 ProbleemNaam in a different profile "zib-Problem"
+    peri32-dataelement-8857 ProbleemNaam in a different profile "zib-Problem"
+    peri32-dataelement-8889 ProbleemNaam in a different profile "zib-Problem"
+    peri32-dataelement-11049 ProbleemNaam in profile ""
+    peri32-dataelement-11035 ProbleemNaam in profile ""
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.337--20210628164200
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.359--20220131105223
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.360--20220131110025
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.361--20220131110815
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.362--20220131111328
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.363--20220131112406
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.364--20220131113252
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.365--20220131114808
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.366--20220131115327
+    Concept(s):    | not found in transactions |
+bc-DisorderOfChild-code WARNING: NOT including ValueSet http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.11.367--20220131120004
+    Concept(s):    | not found in transactions |
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-DisorderOfLaborAndDelivery-code.xml ...
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-DisorderOfPregnancy-code.xml ...
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-DisorderPostPartum-code.xml ...
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-FetusObservation-code.xml ...
+bc-FetusObservation-code WARNING: NOT including Code 281568006 - monitoren van foetale hart (regime/therapie) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-1779 HartslagMeetMethode in a different profile "bc-FetalHeartRate"
+    peri32-dataelement-1197 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-10966 HartslagMeetMethode in profile ""
+    peri31-dataelement-1456 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-1767 Foetale monitoring (CTG) in a different profile "bc-FetalMonitoring"
+    peri32-dataelement-10960 HartslagMeetMethode in a different profile "bc-FetalHeartRate"
+    peri32-dataelement-1536 VerrichtingType in profile ""
+bc-FetusObservation-code WARNING: NOT including Code 441742003 - beoordeling van bevinding (bevinding) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-2355 UitslagInterpretatie in profile ""
+    peri32-dataelement-7846 NavelstrengWaarde in a different profile "bc-UmbilicalCord"
+    peri32-dataelement-1639 UitslagInterpretatie in a different profile "zib-LaboratoryTestResult-Observation"
+bc-FetusObservation-code WARNING: NOT including Code 89087-1 - Fetal Body weight Estimated - http://loinc.org
+    Concept(s):    | not found in transactions |
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-MaternalObservation-code.xml ...
+bc-MaternalObservation-code WARNING: NOT including Code 169740003 - wijze van voeden van zuigeling (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-7946 VoedingMethode in a different profile "bc-FeedingPatternInfant"
+bc-MaternalObservation-code WARNING: NOT including Code 405009004 - infectiestatus (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-3123 WondInfectie in profile "bc-MaternalObservation"
+    peri32-dataelement-2874 WondInfectie in profile "bc-MaternalObservation"
+bc-MaternalObservation-code WARNING: NOT including Code 298007001 - vochtigheid van verwonding (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-3124 WondVochtigheid in profile "bc-MaternalObservation"
+    peri32-dataelement-2875 WondVochtigheid in profile "bc-MaternalObservation"
+bc-MaternalObservation-code WARNING: NOT including Code 449747006 - bevinding betreffende rand van wond (bevinding) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-3125 WondRand in profile "bc-MaternalObservation"
+    peri32-dataelement-2876 WondRand in profile "bc-MaternalObservation"
+bc-MaternalObservation-code WARNING: NOT including Code 401238003 - lengte van verwonding (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):    | not found in transactions |
+bc-MaternalObservation-code WARNING: NOT including Code 401239006 - breedte van verwonding (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):    | not found in transactions |
+bc-MaternalObservation-code WARNING: NOT including Code 425094009 - diepte van verwonding (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):    | not found in transactions |
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-ObstetricProcedure-code.xml ...
+
+Creating /Users/ahenket/Development/GitHub/Nictiz/Geboortezorg-STU3/wikigen/scripts/ValueSets/bc-PregnancyObservation-code.xml ...
+bc-PregnancyObservation-code WARNING: NOT including Code 246435002 - aantal foetussen (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):    | not found in transactions |
+bc-PregnancyObservation-code WARNING: NOT including Code 713651007 - voorgeschiedenis met zwangerschap met abortus als resultaat (situatie) - http://snomed.info/sct
+    Concept(s):    | not found in transactions |
+bc-PregnancyObservation-code WARNING: NOT including Code 59283008 276507005 276506001 - maternale sterfte (gebeurtenis) foetale sterfte (gebeurtenis) neonatale sterfte (gebeurtenis) - http://snomed.info/sct
+    Concept(s):    | not found in transactions |
+bc-PregnancyObservation-code WARNING: NOT including Code 399753006 - datum van overlijden (waarneembare entiteit) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-687 DatumOverlijden in a different profile "nl-core-patient"
+    peri32-dataelement-11028 DatumOverlijden in profile ""
+    peri32-dataelement-10773 DatumOverlijdenZusBroer in profile ""
+    peri32-dataelement-1848 DatumOverlijden in a different profile "nl-core-patient"
+    peri32-dataelement-10552 DatumOverlijden in a different profile "bc-PerinatalDeath"
+bc-PregnancyObservation-code WARNING: NOT including Code 386639001 - afbreken van zwangerschap (verrichting) - http://snomed.info/sct
+    Concept(s):
+    peri32-dataelement-1197 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-1554 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-4147 TypePartusWaarde in a different profile "bc-BirthObservation"
+    peri31-dataelement-1456 VerrichtingType in a different profile "bc-ObstetricProcedure"
+    peri32-dataelement-1536 VerrichtingType in profile ""

--- a/wikigen/scripts/fhirmapping-2-valueset.sh
+++ b/wikigen/scripts/fhirmapping-2-valueset.sh
@@ -1,0 +1,7 @@
+current=`dirname $0`
+java -jar "$current/../../../YATC-tools/saxon/saxon.jar" -xsl:"$current/fhirmapping-2-valueset.xsl" "$current/../../fhirmapping-3-2.xml"  outputdir=$current 
+output=`realpath "${current}/../../profiles/ValueSets/"`
+
+echo Overwriting existing ValueSets/bc*.xml with generated ValueSets/bc*.xml 
+mv ${current}/ValueSets/bc*.xml $output
+rm -rf $current/ValueSets

--- a/wikigen/scripts/fhirmapping-2-valueset.xsl
+++ b/wikigen/scripts/fhirmapping-2-valueset.xsl
@@ -1,0 +1,359 @@
+<!--
+Copyright © Nictiz
+
+This program is free software; you can redistribute it and/or modify it under the terms of the
+GNU Lesser General Public License as published by the Free Software Foundation; either version
+2.1 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+The full text of the license is available at http://www.gnu.org/copyleft/lesser.html
+-->
+<xsl:stylesheet xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:f="http://hl7.org/fhir" xmlns:local="urn:fhir:stu3:functions" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nf="http://www.nictiz.nl/functions" exclude-result-prefixes="#all" version="3.0">
+        
+    <xd:doc scope="stylesheet">
+        <xd:desc>Produces valuesets from FHIR mapping in a folder ValueSets next to this XSL
+            <xd:p><xd:b>Expected input</xd:b> fhirmapping(-3-2).xml</xd:p>
+            <xd:p><xd:b>History:</xd:b>
+                <xd:ul>
+                    <xd:li>2025-08-19 version 0.2 AH</xd:li>
+                    <xd:li>2020-12-02 version 0.1 LM</xd:li>
+                </xd:ul>
+            </xd:p>
+        </xd:desc>
+    </xd:doc>
+    
+    <xsl:import href="../../../YATC-internal/ada-2-fhir/env/fhir/2_fhir_fhir_include.xsl"/>
+    
+    <xsl:output method="xml" indent="yes"/>
+    
+    <xsl:param name="outputdir" select="'.'"/>
+    
+    <xsl:variable name="fhirVersion" select="'3.0'"/>
+    <xsl:variable name="all-profiles" select="collection('../../profiles/?select=*.xml&amp;recurse=yes')//f:StructureDefinition" as="element(f:StructureDefinition)+"/>
+    <xsl:variable name="fhirmapping-file" select="doc('../../fhirmapping-3-2.xml')/*" as="element()+"/>
+    <xsl:variable name="ada-release-file" select="doc('../../../art_decor/projects/perinatologie-326/definitions/perinatologie-326-ada-release.xml')/*" as="element()"/>
+    
+    <xsl:variable name="allValueSets" select="collection('../../profiles/ValueSets?select=*.xml&amp;recurse=yes')//f:ValueSet"/>
+    <xsl:variable name="valueSets" as="element(f:ValueSet)*">
+        <xsl:for-each select="$allValueSets[starts-with(f:name/@value, 'bc-')]">
+            <xsl:choose>
+                <xsl:when test="descendant::f:valueSet">
+                    <xsl:copy>
+                        <xsl:copy-of select="* except f:compose"/>
+                        <xsl:for-each select="f:compose">
+                            <xsl:copy>
+                                <xsl:copy-of select="f:lockedDate | f:inactive"/>
+                                <xsl:for-each select="f:include">
+                                    <xsl:copy>
+                                        <xsl:copy-of select="* except f:valueSet"/>
+                                        <xsl:for-each select="f:valueSet">
+                                            <xsl:copy>
+                                                <xsl:copy-of select="@*"/>
+                                                <xsl:copy-of select="$allValueSets[f:url/@value = current()/@value]"/>
+                                            </xsl:copy>
+                                        </xsl:for-each>
+                                    </xsl:copy>
+                                </xsl:for-each>
+                            </xsl:copy>
+                        </xsl:for-each>
+                    </xsl:copy>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:sequence select="."/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+    </xsl:variable>
+    
+    <!-- 
+        <record>
+            <ID>peri32-dataelement-10867</ID>
+            <naam>Documentgegevens</naam>
+            <mapping>DocumentReference</mapping>
+            <profile>IHE.MHD.Minimal.DocumentReference</profile>
+        </record>
+    -->
+    <!--
+        <mapping>
+            <identity value="gebz-peri-v3.2" />
+            <map value="peri32-dataelement-8873" />
+            <comment value="Identificatie zorgepisode" />
+        </mapping>
+    -->
+    <xsl:template match="/">
+        
+        <xsl:call-template name="doValueSetsForCode"/>
+        
+    </xsl:template>
+    
+    <xsl:template name="doValueSetsForCode">
+        
+        <!-- These concepts do not have a parent mapping onto the resource level to we they directly go into e.g. Observation.value -->
+        <xsl:variable name="valueConcepts" as="element()*">
+            <record id="peri32-dataelement-1729">Datum einde zwangerschap</record>
+            <record id="peri32-dataelement-2913">SociaalNetwerk</record>
+            <record id="peri32-dataelement-10774">UrinatieGeweest?</record>
+            <record id="peri32-dataelement-10775">DefecatieGeweest?</record>
+            <record id="peri32-dataelement-3115">Lochia foetide / riekend?</record>
+            <record id="peri32-dataelement-3117">Grote stolsels in lochia (Waarde)</record>
+        </xsl:variable>
+        <!-- Get fhirmapping records - grouped per profile - that map into bc profiles at root resource level, e.g. Condition or Observation -->
+        <xsl:for-each-group select="$fhirmapping-file/record[string-length(profile[starts-with(., 'bc-')]) gt 0][not(contains(mapping, '.')) or ID = $valueConcepts/@id]" group-by="profile">
+            <xsl:sort select="current-grouping-key()"/>
+            <xsl:variable name="mappingRecords" as="element(record)+" select="current-group()"/>
+            
+            <!-- Get the relevant StructureDefinition (profile) -->
+            <xsl:variable name="theProfile" select="$all-profiles[ends-with(f:url/@value, current-grouping-key())]" as="element(f:StructureDefinition)"/>
+            <!-- Get the current ValueSet for the -code element. Expect [profile.name]-code as its name -->
+            <xsl:variable name="theValueSet" select="$valueSets[ends-with(f:url/@value, concat(current-grouping-key(), '-code'))]" as="element(f:ValueSet)?"/>
+            
+            <!-- If there is no current value set for the profile, then skip the rest. Apparently no such ValueSet is needed for this profile -->
+            <xsl:if test="$theValueSet">
+                
+                <!-- Get the terminologyAssociations from the dataset (ADA Release file). These are not always attached to the concept mentioned in the fhirmapping record. They might be connected to a specific child concept -->
+                <xsl:variable name="terminologyAssociations" as="element()*">
+                    <xsl:for-each select="$mappingRecords/ID">
+                        <xsl:variable name="theConcept" select="nf:getDataConcept(.)"/>
+                        <xsl:choose>
+                            <xsl:when test="$theConcept/concept[name[. = 'ProbleemNaam']]/valueSet">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'ProbleemNaam']]/valueSet/terminologyAssociation[@valueSet]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[. = 'VerrichtingType']]/valueSet">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'VerrichtingType']]/valueSet/terminologyAssociation[@valueSet]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[. = 'ObservatieNaam']]/valueSet">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'ObservatieNaam']]/valueSet/terminologyAssociation[@valueSet]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[. = 'SonomarkerNaam']]/valueSet">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'SonomarkerNaam']]/valueSet/terminologyAssociation[@valueSet]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[. = 'Schooltype']]">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'Schooltype']]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept[name[. = 'Maternale sterfte']]">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'OverlijdensIndicator']]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)][@code = '59283008']"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept[name[. = 'Perinatale sterfte']]">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'OverlijdensIndicator']]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)][not(@code = '59283008')]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[. = 'ZelfredzaamheidAndersDanVerwachting']]">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'ZelfredzaamheidAndersDanVerwachting']]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept[name[. = 'Continentie']]">
+                                <xsl:sequence select="$theConcept/concept[name[. = ('UrineContinentie', 'FecesContinentie', 'Flatusincontinentie')]]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[. = 'ATermeDatum']]">
+                                <xsl:sequence select="$theConcept/concept[name[. = 'ATermeDatum']]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]">
+                                <xsl:sequence select="$theConcept/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/valueSet">
+                                <xsl:sequence select="$theConcept/valueSet"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[ends-with(., 'Waarde')]]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]">
+                                <xsl:sequence select="$theConcept/concept[name[ends-with(., 'Waarde') or . = 'ProbleemNaam']]/terminologyAssociation[@conceptId = (../@id | ../inherit/@ref)]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept/concept[name[ends-with(., 'Waarde')]]">
+                                <xsl:sequence select="$theConcept/concept[name[ends-with(., 'Waarde') or . = 'ProbleemNaam']]/valueSet/terminologyAssociation[@valueSet]"/>
+                            </xsl:when>
+                            <xsl:when test="$theConcept[valueDomain | concept[valueDomain][not(contains)]]">
+                                <xsl:message><xsl:value-of select="current-grouping-key()"/><xsl:text>: MISSING association for </xsl:text><xsl:value-of select="."/><xsl:text> </xsl:text><xsl:value-of select="$theConcept/(name[@language = 'nl-NL'], name)[1]"/></xsl:message>
+                            </xsl:when>
+                            <!--<xsl:otherwise>
+                                <xsl:message><xsl:value-of select="current-grouping-key()"/><xsl:text>: NO TRANSACTION for </xsl:text><xsl:value-of select="."/></xsl:message>
+                            </xsl:otherwise>-->
+                        </xsl:choose>
+                    </xsl:for-each>
+                </xsl:variable>
+                
+                <!-- Check the current ValueSet for things - concepts and/or value sets - that will not be present in the new data. We will copy those into the new value set as comments -->
+                <xsl:variable name="extraTerminologyAssociations" select="$theValueSet/f:compose/f:include/f:concept[not(f:code/@value = $terminologyAssociations/@code)] | 
+                                                                          $theValueSet/f:compose/f:include/f:valueSet[not(substring-before(tokenize(@value, '/')[last()], '--') = $terminologyAssociations/@valueSet)]" as="element()*"/>
+                
+                <!-- Start building the ValueSet -->
+                <xsl:message>Creating <xsl:value-of select="$outputdir"/>/ValueSets/<xsl:value-of select="current-grouping-key()"/>-code.xml ...</xsl:message>
+                <xsl:result-document href="{$outputdir}/ValueSets/{current-grouping-key()}-code.xml" indent="yes" omit-xml-declaration="yes">
+                    <ValueSet xmlns="http://hl7.org/fhir">
+                        <id value="{current-grouping-key()}-code"/>
+                        <meta>
+                            <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+                        </meta>
+                        <url value="http://nictiz.nl/fhir/ValueSet/{current-grouping-key()}-code"/>
+                        <version value="1.3.3"/>
+                        <name value="{current-grouping-key()}-code"/>
+                        <title value="{current-grouping-key()}-code"/>
+                        <status value="draft"/>
+                        <experimental value="false"/>
+                        <publisher value="Nictiz"/>
+                        <description value="{current-grouping-key()}-code"/>
+                        <immutable value="false"/>
+                        <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+                        <compose>
+                            <!-- Create compose.include elements per code system -->
+                            <xsl:for-each-group select="$terminologyAssociations[@code][@codeSystem]" group-by="@codeSystem">
+                                <include>
+                                    <system value="{local:getUri(current-grouping-key())}"/>
+                                    
+                                    <!-- Create include.concept elements preventing duplicates -->
+                                    <xsl:for-each-group select="current-group()" group-by="@code">
+                                        <!--<xsl:comment><xsl:text> </xsl:text><xsl:value-of select="../@iddisplay"/><xsl:text> </xsl:text><xsl:value-of select="../(name[@language = 'nl-NL'], name)[1]"/><xsl:text> </xsl:text></xsl:comment>-->
+                                        <concept>
+                                            <!-- http://hl7.org/fhir/StructureDefinition/valueset-comments would have worked, but only for this context and not for include.valueSet
+                                                    https://jira.hl7.org/browse/FHIR-51904 -->
+                                            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+                                                <valueString value="{../@iddisplay,../(name[@language = 'nl-NL'], name)[1]}"/>
+                                            </extension>
+                                            <code value="{current-grouping-key()}"/>
+                                            <display value="{current-group()[1]/@displayName}"/>
+                                        </concept>
+                                    </xsl:for-each-group>
+                                </include>
+                            </xsl:for-each-group>
+                            <!-- Create compose.include elements per valueSet preventing duplicates ... technically they could be in a single include but left it the way I found it -->
+                            <xsl:for-each-group select="$terminologyAssociations[@valueSet]" group-by="@valueSet">
+                                
+                                <!-- If the terminologyAssociation has flexibility dynmic we might be able to get it from the valueSet ... but if the concept has multiple valueSets 
+                                    connected, then those are merged into a single valueSet which looses the metadata from all but 1 valueSet. so as last resort we might be able to 
+                                    check the exported set of ValueSets where our target probably exists: error if all fails -->
+                                <xsl:variable name="valueSetEffectiveDate" as="attribute()">
+                                    <xsl:choose>
+                                        <xsl:when test="current-group()/@flexibility[. castable as xs:dateTime]">
+                                            <xsl:sequence select="current-group()/@flexibility[. castable as xs:dateTime]"/>
+                                        </xsl:when>
+                                        <xsl:when test="current-group()/parent::valueSet[@id = current-grouping-key()]/@effectiveDate">
+                                            <xsl:sequence select="current-group()/parent::valueSet[@id = current-grouping-key()]/@effectiveDate"/>
+                                        </xsl:when>
+                                        <xsl:when test="$allValueSets[f:url[contains(@value, concat('/', current-grouping-key()))]]">
+                                            <xsl:sequence select="$allValueSets[f:url[contains(@value, concat('/', current-grouping-key()))]]/f:extension[@url='http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod']/f:valuePeriod/f:start/@value"/>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:message>NOT FOUND effectiveDate for ValueSet <xsl:value-of select="current-grouping-key()"/><xsl:text> </xsl:text><xsl:value-of select="current-group()[1]/@valueSetName"/></xsl:message>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:variable>
+                                
+                                <!--<xsl:comment><xsl:text> </xsl:text><xsl:value-of select="ancestor::concept[1]/@iddisplay"/><xsl:text> </xsl:text><xsl:value-of select="ancestor::concept[1]/(name[@language = 'nl-NL'], name)[1]"/><xsl:text> </xsl:text></xsl:comment>-->
+                                <include>
+                                    <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/{current-grouping-key()}--{replace($valueSetEffectiveDate[1], '\D', '')}">
+                                        <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+                                            <valueString value="{ancestor::concept[1]/@iddisplay, ancestor::concept[1]/(name[@language = 'nl-NL'], name)[1]}"/>
+                                        </extension>
+                                    </valueSet>
+                                </include>
+                            </xsl:for-each-group>
+                            
+                            <!-- Some of the existing ValueSets for -code have include of full code system (normally LOINC). Not sure why but keep those as we will not get that knowledge from the dataset -->
+                            <xsl:copy-of select="$theValueSet/f:compose/f:include[f:system][empty(f:concept | f:valueSet)]"/>
+                            
+                            <!-- If there is more terminology in the original value set then we currently have, we check what profile this temrinology should now be in by looking up the dataset concept 
+                                that this terminology belongs to, and subsequently the mapping(s) this concept has. If the terminology is connected to a concept that also maps into the current profile, then
+                                it is added as comment in the new ValueSet. This should be looked into, as there should not be any comment like that. Any terminology relevant for the current profile should 
+                                have been captured in $terminologyAssociations  -->
+                            <xsl:for-each select="$extraTerminologyAssociations">
+                                <xsl:variable name="associatedConcept" select="$ada-release-file//concept[terminologyAssociation/@code = current()/f:code/@value] | 
+                                                                               $ada-release-file//concept[terminologyAssociation/@valueSet = current()/substring-before(tokenize(@value, '/')[last()], '--')] |
+                                                                               $ada-release-file//concept[valueSet//@code = current()/f:code/@value]"/>
+                                <xsl:variable name="associatedMapping" select="$fhirmapping-file//record[ID = $associatedConcept/@iddisplay]/profile"/>
+                                <xsl:if test="$associatedMapping = $theProfile/f:name/@value">
+                                    <xsl:comment>
+                                        <xsl:for-each-group select="$associatedConcept" group-by="@id">
+                                            <xsl:value-of select="current-group()[1]/@iddisplay"/>
+                                            <xsl:text> </xsl:text>
+                                            <xsl:value-of select="(name[@language = 'nl-NL'], name)[1]"/>
+                                            <xsl:text> in profile "</xsl:text>
+                                            <xsl:value-of select="$fhirmapping-file//record[ID = current()/@iddisplay]/profile"/>
+                                            <xsl:text>"</xsl:text>
+                                            <xsl:if test="position() != last()">
+                                                <xsl:text>
+          </xsl:text>
+                                            </xsl:if>
+                                        </xsl:for-each-group>
+                                    </xsl:comment>
+                                    <xsl:choose>
+                                        <xsl:when test="f:code">
+                                            <xsl:comment>
+                                            <xsl:text>&lt;concept&gt;
+              </xsl:text>
+                                            <xsl:text>&lt;code value="</xsl:text>
+                                            <xsl:value-of select="f:code/@value"/>
+                                            <xsl:text>"/&gt;
+              </xsl:text>
+                                            <xsl:text>&lt;display value="</xsl:text>
+                                            <xsl:value-of select="f:display/@value"/>
+                                            <xsl:text>"/&gt;
+          </xsl:text>
+                                            <xsl:text>&lt;/concept&gt;</xsl:text>
+                                        </xsl:comment>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:comment>
+                                            <xsl:text>&lt;valueSet value="</xsl:text>
+                                            <xsl:value-of select="replace(@value, '--', '-\\-')"/>
+                                            <xsl:text>"/&gt;</xsl:text>
+                                        </xsl:comment>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                    <xsl:comment>=========================================================</xsl:comment>
+                                </xsl:if>
+                                
+                                <xsl:message>
+                                    <xsl:value-of select="$theProfile/f:name/@value"/><xsl:text>-code WARNING: NOT including </xsl:text>
+                                    <xsl:choose>
+                                        <xsl:when test="self::f:valueSet">
+                                            <xsl:text>ValueSet </xsl:text><xsl:value-of select="@value"/>
+                                        </xsl:when>
+                                        <xsl:when test="self::f:concept">
+                                            <xsl:text>Code </xsl:text><xsl:value-of select="f:code/@value"/>
+                                            <xsl:text> - </xsl:text><xsl:value-of select="f:display/@value"/>
+                                            <xsl:text> - </xsl:text><xsl:value-of select="../f:system/@value"/>
+                                        </xsl:when>
+                                    </xsl:choose>
+                                    <xsl:text>
+</xsl:text>
+                                    <xsl:text>    Concept(s):</xsl:text>
+                                    <xsl:for-each-group select="$associatedConcept" group-by="@id">
+                                        <xsl:variable name="associatedProfile" select="$fhirmapping-file//record[ID = current()/@iddisplay]/profile"/>
+                                        <xsl:text>
+    </xsl:text>
+                                        <xsl:value-of select="current-group()[1]/@iddisplay"/>
+                                        <xsl:text> </xsl:text>
+                                        <xsl:value-of select="(name[@language = 'nl-NL'], name)[1]"/>
+                                        <xsl:text> in</xsl:text>
+                                        <xsl:if test="$associatedProfile != $theProfile/f:name/@value"> a different</xsl:if>
+                                        <xsl:text> profile "</xsl:text>
+                                        <xsl:value-of select="$fhirmapping-file//record[ID = current()/@iddisplay]/profile"/>
+                                        <xsl:text>"</xsl:text>
+                                    </xsl:for-each-group>
+                                    <xsl:if test="empty($associatedConcept)">
+                                        <xsl:text>    | not found in transactions |</xsl:text>
+                                    </xsl:if>
+                                </xsl:message>
+                            </xsl:for-each>
+                        </compose>
+                    </ValueSet>
+                    
+                </xsl:result-document>
+            </xsl:if>
+        </xsl:for-each-group>
+        
+    </xsl:template>
+    
+    <xsl:function name="nf:getDataConcept" as="element(concept)?">
+        <xsl:param name="conceptId"/>
+        
+        <xsl:variable name="theConcept" select="($ada-release-file//concept[@id = $conceptId or @iddisplay = $conceptId])[1]"/>
+        <xsl:choose>
+            <xsl:when test="$theConcept[contains]">
+                <xsl:sequence select="nf:getDataConcept($theConcept/contains/@ref)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$theConcept"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+</xsl:stylesheet>

--- a/wikigen/scripts/fhirmapping-report.cmd
+++ b/wikigen/scripts/fhirmapping-report.cmd
@@ -1,0 +1,1 @@
+java -jar "%~dp0../../../YATC-tools/saxon/saxon.jar" -xsl:"%~dp0fhirmapping-report.xsl" "%~dp0../../fhirmapping-3-2.xml"   outputdir=%~dp0

--- a/wikigen/scripts/fhirmapping-report.html
+++ b/wikigen/scripts/fhirmapping-report.html
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <html>
    <head>
       <title>Mapping report</title>
+      <meta charset="UTF-8"> </meta>
       <style>
                         * { font-family: Verdana, sans-serif; } 
                         tr:nth-child(even) { background-color: lightgrey; } 
@@ -13,18 +13,19 @@
    </head>
    <body>
       <h3>Mapping report</h3>
-      <div>Generated: 2025-08-20T10:58:59.603593+02:00</div>
-      <div>Mappings in fhirmapping-3-2.xml: 3305</div>
-      <div>Mappings in profiles/extensions: 1499</div>
+      <div>Generated: 2025-08-22T15:24:20.761039+02:00</div>
+      <div>Mappings in fhirmapping-3-2.xml: total=3323, present in transaction=<b>2098</b> (table only lists mappings related to PWD 3.2 transactions)</div>
+      <div>Mappings in profiles/extensions: 1497</div>
       <div>
          <input id="hide-valid"
                 type="checkbox"
                 name="hide-valid"
                 style="margin-left: 1em;"
                 onchange="showHideRows()">Hide valid</input>
-                        - valid: 3282
-                        - with transaction issue: 0
-                        - with profile issue: 0</div>
+                        - valid: <b>2098</b>
+                        - with transaction issue: <span style="font-weight: bold; color:green;">0</span>
+                        - with profile issue: <span style="font-weight: bold; color:green;">0</span>
+      </div>
       <table>
          <tr>
             <th colspan="4">Source: fhirmapping-3-2.xml</th>
@@ -39,15 +40,6 @@
             <th>Transaction(s)</th>
             <th>Profiles</th>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1313</td>
             <td>
@@ -58,9 +50,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -81,8 +70,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -103,7 +90,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -116,15 +102,14 @@
                <div title="Administratief/Betaler/BetalerPersoon/BetalerNaam">BetalerNaam</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.name</div>
+               <div>Patient.name</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -145,7 +130,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -166,7 +150,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -187,7 +170,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -208,7 +190,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -229,8 +210,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -251,8 +230,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -273,8 +250,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -295,8 +270,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -317,8 +290,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -339,8 +310,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -361,8 +330,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -383,8 +350,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -397,15 +362,14 @@
                <div title="Administratief/Betaler/Adresgegevens">Adresgegevens</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address</div>
+               <div>Patient.address</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -418,15 +382,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Straat">Straat</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line:line.streetName</div>
+               <div>Patient.address.line:line.streetName</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -439,15 +402,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Huisnummer">Huisnummer</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line:houseNumber</div>
+               <div>Patient.address.line:houseNumber</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -460,15 +422,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Huisnummerletter">Huisnummerletter</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line:extension:buildingNumbersuffix</div>
+               <div>Patient.address.line:extension:buildingNumbersuffix</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -481,15 +442,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Huisnummertoevoeging">Huisnummertoevoeging</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line:extension:buildingNumbersuffix</div>
+               <div>Patient.address.line:extension:buildingNumbersuffix</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -502,15 +462,14 @@
                <div title="Administratief/Betaler/Adresgegevens/AanduidingBijNummer">AanduidingBijNummer</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line.extension:additionalLocator</div>
+               <div>Patient.address.line.extension:additionalLocator</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -523,15 +482,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Postcode">Postcode</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line.postalCode</div>
+               <div>Patient.address.line.postalCode</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -544,15 +502,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Woonplaats">Woonplaats</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line.city</div>
+               <div>Patient.address.line.city</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -565,15 +522,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Gemeente">Gemeente</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line.district</div>
+               <div>Patient.address.line.district</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -586,15 +542,14 @@
                <div title="Administratief/Betaler/Adresgegevens/Land">Land</div>
             </td>
             <td>
-               <div>Patient/RelatedPersonaddress.country</div>
+               <div>Patient.address.country</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -607,15 +562,14 @@
                <div title="Administratief/Betaler/Adresgegevens/AdditioneleInformatie">AdditioneleInformatie</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.line.extension:unitID</div>
+               <div>Patient.address.line.extension:unitID</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -628,15 +582,14 @@
                <div title="Administratief/Betaler/Adresgegevens/AdresSoort">AdresSoort</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.address.type/.use (via conceptmap)</div>
+               <div>Patient.address.type/.use (via conceptmap)</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -649,15 +602,14 @@
                <div title="Administratief/Betaler/Contactgegevens">Contactgegevens</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom</div>
+               <div>Patient.telecom</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -670,15 +622,14 @@
                <div title="Administratief/Betaler/Contactgegevens/Telefoonnummers">Telefoonnummers</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom</div>
+               <div>Patient.telecom</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -691,15 +642,14 @@
                <div title="Administratief/Betaler/Contactgegevens/Telefoonnummers/Telefoonnummer">Telefoonnummer</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom.value</div>
+               <div>Patient.telecom.value</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -712,15 +662,14 @@
                <div title="Administratief/Betaler/Contactgegevens/Telefoonnummers/TelecomType">TelecomType</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom:extension:TelecomType</div>
+               <div>Patient.telecom:extension:TelecomType</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -733,15 +682,14 @@
                <div title="Administratief/Betaler/Contactgegevens/Telefoonnummers/NummerSoort">NummerSoort</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom.use</div>
+               <div>Patient.telecom.use</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -754,15 +702,14 @@
                <div title="Administratief/Betaler/Contactgegevens/EmailAdressen">EmailAdressen</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom.value</div>
+               <div>Patient.telecom.value</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -775,15 +722,14 @@
                <div title="Administratief/Betaler/Contactgegevens/EmailAdressen/EmailAdres">EmailAdres</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom.value</div>
+               <div>Patient.telecom.value</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -796,15 +742,14 @@
                <div title="Administratief/Betaler/Contactgegevens/EmailAdressen/EmailSoort">EmailSoort</div>
             </td>
             <td>
-               <div>Patient/RelatedPerson.telecom.use</div>
+               <div>Patient.telecom.use</div>
             </td>
             <td>
-               <div>nl-core-patient/nl-core-relatedperson</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -825,8 +770,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -850,8 +793,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -875,8 +816,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -900,8 +839,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -914,7 +851,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1868</td>
             <td>
-               <div title="Administratief/Contact/ContactMet/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner.participant.individual</div>
@@ -924,9 +861,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -947,8 +882,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -961,7 +894,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1881</td>
             <td>
-               <div title="Administratief/Contact/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -971,9 +904,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -994,8 +925,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1019,8 +948,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1044,8 +971,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1069,8 +994,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1091,8 +1014,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1102,7 +1023,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3828</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Vrouw/ moeder/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
+               <div title="Vrouw/Anamnese/Algemene anamnese/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1112,9 +1033,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1124,7 +1043,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3831</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Vrouw/ moeder/Probleem (Psychiatrie)">Probleem (Psychiatrie)</div>
+               <div title="Vrouw/Anamnese/Psychische en/of Sociale problemen/Probleem (Psychiatrie)">Probleem (Psychiatrie)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1134,9 +1053,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1146,7 +1063,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3829</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Vrouw/ moeder/Probleem (Sociale problemen)">Probleem (Sociale problemen)</div>
+               <div title="Vrouw/Anamnese/Psychische en/of Sociale problemen/Probleem (Sociale problemen)">Probleem (Sociale problemen)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1156,9 +1073,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1168,7 +1083,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3832</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Vrouw/ moeder/Probleem (Misbruik/ Geweld)">Probleem (Misbruik/ Geweld)</div>
+               <div title="Vrouw/Anamnese/Psychische en/of Sociale problemen/Probleem (Misbruik/ Geweld)">Probleem (Misbruik/ Geweld)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1178,9 +1093,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1190,7 +1103,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3830</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Vrouw/ moeder/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
+               <div title="Zwangerschapsgegevens/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1200,9 +1113,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1215,7 +1126,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1928</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Vrouw/ moeder/Probleem (Maternaal)">Probleem (Maternaal)</div>
+               <div title="Bevalling/Probleem (Maternaal)">Probleem (Maternaal)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1225,9 +1136,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1240,7 +1149,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3833</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Vrouw/ moeder/Probleem (Postpartum complicatie)">Probleem (Postpartum complicatie)</div>
+               <div title="Postnatale fase/Moeder/Probleem (Postpartum complicatie)">Probleem (Postpartum complicatie)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1250,9 +1159,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1276,8 +1183,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1290,7 +1195,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1981</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem (Kindspecifieke maternale problemen)">Probleem (Kindspecifieke maternale problemen)</div>
+               <div title="Bevalling/Uitdrijvingsfase/Probleem (Kindspecifieke maternale problemen)">Probleem (Kindspecifieke maternale problemen)</div>
             </td>
             <td>
                <div>Condition.code</div>
@@ -1300,9 +1205,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1315,7 +1218,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1983</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem (ProblematiekKind)">Probleem (ProblematiekKind)</div>
+               <div title="Kind/Problematiek kind/Probleem (ProblematiekKind)">Probleem (ProblematiekKind)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1325,9 +1228,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1340,7 +1241,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8781</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem (Geboortetrauma)">Probleem (Geboortetrauma)</div>
+               <div title="Kind/Problematiek kind/Geboortetrauma/Probleem (Geboortetrauma)">Probleem (Geboortetrauma)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1350,9 +1251,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1365,7 +1264,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8782</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem (Congenitale aandoeningen)">Probleem (Congenitale aandoeningen)</div>
+               <div title="Kind/Problematiek kind/Congenitale aandoeningen/Probleem (Congenitale aandoeningen)">Probleem (Congenitale aandoeningen)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1375,9 +1274,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1390,7 +1287,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8783</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Huid">Probleem_Huid</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Huid/Probleem_Huid">Probleem_Huid</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1400,8 +1297,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1414,7 +1310,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8784</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Hoofd/Hals">Probleem_Hoofd/Hals</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Hoofd/Hals/Probleem_Hoofd/Hals">Probleem_Hoofd/Hals</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1424,8 +1320,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1438,7 +1333,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8785</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Thorax">Probleem_Thorax</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax">Probleem_Thorax</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1448,8 +1343,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1462,7 +1356,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8786</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Abdomen">Probleem_Abdomen</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Abdomen/Probleem_Abdomen">Probleem_Abdomen</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1472,8 +1366,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1486,7 +1379,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8787</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Rug">Probleem_Rug</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Rug/Probleem_Rug">Probleem_Rug</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1496,8 +1389,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1510,7 +1402,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8788</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Extremiteiten">Probleem_Extremiteiten</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Extremiteiten/Probleem_Extremiteiten">Probleem_Extremiteiten</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1520,8 +1412,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1534,7 +1425,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8789</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Genitalia">Probleem_Genitalia</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Genitalia/Probleem_Genitalia">Probleem_Genitalia</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1544,8 +1435,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1558,7 +1448,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8790</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem_Neurologie">Probleem_Neurologie</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Neurologie/Probleem_Neurologie">Probleem_Neurologie</div>
             </td>
             <td>
                <div>Condition</div>
@@ -1568,8 +1458,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1585,10 +1474,10 @@
                <div title="Administratief/Contact/RedenContact/Probleem/Kind/Probleem (OpnameIndicatie_LNR)">Probleem (OpnameIndicatie_LNR)</div>
             </td>
             <td>
-               <div>nvt</div>
+               <div>Condition</div>
             </td>
             <td>
-               <div>nvt</div>
+               <div>bc-DisorderOfChild</div>
             </td>
             <td>
                <ul>
@@ -1596,7 +1485,10 @@
                </ul>
             </td>
             <td>
-               <span style="font-style: italic;">No mappings</span>
+               <ul>
+                  <li>Mapping <span>bc-DisorderOfChild</span> - path <span>Condition</span>
+                  </li>
+               </ul>
             </td>
          </tr>
          <tr class="row-valid">
@@ -1820,7 +1712,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1841,7 +1732,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1851,7 +1741,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3834</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Vrouw/ moeder/Verrichting (Algemene anamnese)">Verrichting (Algemene anamnese)</div>
+               <div title="Vrouw/Anamnese/Algemene anamnese/Verrichting (Algemene anamnese)">Verrichting (Algemene anamnese)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -1861,8 +1751,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1872,7 +1761,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3835</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Vrouw/ moeder/Verrichting (Zwangerschap)">Verrichting (Zwangerschap)</div>
+               <div title="Zwangerschapsgegevens/Verrichting (Zwangerschap)">Verrichting (Zwangerschap)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -1882,8 +1771,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1896,7 +1784,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1970</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Vrouw/ moeder/Verrichting (Maternaal)">Verrichting (Maternaal)</div>
+               <div title="Bevalling/Verrichting (Maternaal)">Verrichting (Maternaal)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -1906,8 +1794,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1920,7 +1807,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3836</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Vrouw/ moeder/Verrichting (Onderzoek)">Verrichting (Onderzoek)</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)">Verrichting (Onderzoek)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -1931,7 +1818,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1941,7 +1827,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3837</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Vrouw/ moeder/Verrichting (Postpartum complicatie)">Verrichting (Postpartum complicatie)</div>
+               <div title="Postnatale fase/Moeder/Verrichting (Postpartum complicatie)">Verrichting (Postpartum complicatie)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -1951,7 +1837,6 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                   <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
@@ -1976,7 +1861,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -1989,7 +1873,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1982</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Kind/Verrichting (Kindspecifieke maternale verrichtingen)">Verrichting (Kindspecifieke maternale verrichtingen)</div>
+               <div title="Bevalling/Uitdrijvingsfase/Verrichting (Kindspecifieke maternale verrichtingen)">Verrichting (Kindspecifieke maternale verrichtingen)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -1999,8 +1883,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2013,7 +1896,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8791</td>
             <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Kind/Verrichting (Ondersteuning opvang)">Verrichting (Ondersteuning opvang)</div>
+               <div title="Kind/Ondersteuning opvang/Verrichting (Ondersteuning opvang)">Verrichting (Ondersteuning opvang)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -2023,56 +1906,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-ObstetricProcedure</span> - path <span>Procedure</span>
-                  </li>
-               </ul>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-8792</td>
-            <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Kind/Chirurgische ingrepen (Verrichting)">Chirurgische ingrepen (Verrichting)</div>
-            </td>
-            <td>
-               <div>Procedure</div>
-            </td>
-            <td>
-               <div>bc-ObstetricProcedure</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-ObstetricProcedure</span> - path <span>Procedure</span>
-                  </li>
-               </ul>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-8793</td>
-            <td>
-               <div title="Administratief/Contact/RedenContact/Verrichting/Kind/Verrichting (Problematiek kind)">Verrichting (Problematiek kind)</div>
-            </td>
-            <td>
-               <div>Procedure</div>
-            </td>
-            <td>
-               <div>bc-ObstetricProcedure</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2096,8 +1930,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2121,8 +1953,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2146,8 +1976,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2171,8 +1999,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2196,7 +2022,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2217,7 +2042,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2238,7 +2062,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2259,7 +2082,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2280,7 +2102,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2301,7 +2122,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2322,7 +2142,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2343,7 +2162,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2364,7 +2182,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2385,7 +2202,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2406,7 +2222,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2427,7 +2242,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2448,7 +2262,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2469,7 +2282,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2490,7 +2302,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2511,7 +2322,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2532,7 +2342,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2553,7 +2362,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2574,7 +2382,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2595,7 +2402,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2616,7 +2422,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2637,7 +2442,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2658,7 +2462,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2679,7 +2482,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2700,7 +2502,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2721,7 +2522,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2742,7 +2542,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2763,7 +2562,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2784,7 +2582,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2805,7 +2602,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2826,7 +2622,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2847,7 +2642,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2868,7 +2662,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2889,7 +2682,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2910,9 +2702,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2933,9 +2722,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2956,9 +2742,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -2979,9 +2762,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3002,9 +2782,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3025,9 +2802,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3048,9 +2822,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3071,9 +2842,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3094,9 +2862,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3117,9 +2882,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3140,9 +2902,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3163,9 +2922,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3186,9 +2942,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3209,9 +2962,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3232,9 +2982,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3255,9 +3002,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3278,9 +3022,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3301,9 +3042,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3324,9 +3062,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3347,9 +3082,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3370,9 +3102,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3393,9 +3122,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3416,9 +3142,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3439,9 +3162,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3462,9 +3182,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3485,9 +3202,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3508,9 +3222,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3531,9 +3242,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3554,9 +3262,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3577,9 +3282,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3600,9 +3302,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3623,9 +3322,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3646,9 +3342,6 @@
             <td>
                <ul>
                   <li>0..* C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3669,9 +3362,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3695,9 +3385,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3718,9 +3405,6 @@
             <td>
                <ul>
                   <li>0..* C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3741,8 +3425,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3766,9 +3448,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3789,9 +3468,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3812,9 +3488,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3835,9 +3508,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3858,7 +3528,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3882,7 +3551,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3906,7 +3574,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3930,7 +3597,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3956,7 +3622,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -3982,9 +3647,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4005,9 +3667,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4028,9 +3687,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4051,7 +3707,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4072,8 +3727,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4094,7 +3747,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4115,7 +3767,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4136,7 +3787,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4157,7 +3807,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4178,7 +3827,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4199,7 +3847,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4220,7 +3867,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4241,7 +3887,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4262,8 +3907,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4284,8 +3927,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4306,8 +3947,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4328,8 +3967,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4350,8 +3987,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4372,8 +4007,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4394,8 +4027,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4416,8 +4047,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4438,8 +4067,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4460,8 +4087,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4482,8 +4107,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4504,8 +4127,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4526,9 +4147,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4549,9 +4167,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4572,9 +4187,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4595,9 +4207,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4618,9 +4227,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4641,9 +4247,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4664,9 +4267,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4687,9 +4287,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4710,9 +4307,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4733,9 +4327,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4756,9 +4347,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4779,9 +4367,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4802,9 +4387,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4825,9 +4407,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -4848,8 +4427,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5110,7 +4687,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5131,7 +4707,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5152,7 +4727,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5173,7 +4747,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5263,7 +4836,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1678</td>
             <td>
-               <div title="Administratief/Zorgverlener/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -5273,9 +4846,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5296,7 +4867,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5320,9 +4890,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5449,7 +5016,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3865</td>
             <td>
-               <div title="Zorgverlening/ZorgAfspraak/AfspraakPartijen/Patiënt/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>CarePlan.author</div>
@@ -5459,7 +5026,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5495,7 +5062,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3866</td>
             <td>
-               <div title="Zorgverlening/ZorgAfspraak/AfspraakPartijen/Contactpersoon/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>CarePlan.author</div>
@@ -5505,7 +5072,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5543,7 +5110,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3867</td>
             <td>
-               <div title="Zorgverlening/ZorgAfspraak/AfspraakPartijen/Zorgverlener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>CarePlan.author</div>
@@ -5553,7 +5120,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5614,7 +5181,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3868</td>
             <td>
-               <div title="Zorgverlening/ZorgAfspraak/Uitvoerder/Patient/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Patient</div>
@@ -5624,7 +5191,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5657,7 +5224,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3869</td>
             <td>
-               <div title="Zorgverlening/ZorgAfspraak/Uitvoerder/Contactpersoon/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>RelatedPerson</div>
@@ -5667,7 +5234,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5700,7 +5267,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3870</td>
             <td>
-               <div title="Zorgverlening/ZorgAfspraak/Uitvoerder/Zorgverlener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>PractitionerRole</div>
@@ -5710,7 +5277,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -5743,7 +5310,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3864</td>
             <td>
-               <div title="Zorgverlening/ZorgAfspraak/Coordinator/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>PractitionerRole</div>
@@ -5753,7 +5320,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6081,7 +5648,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2627</td>
             <td>
-               <div title="Zorgverlening/Conclusie professioneel onderzoek/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>ClinicalImpression.assessor</div>
@@ -6091,7 +5658,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6104,7 +5671,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3634</td>
             <td>
-               <div title="Zorgverlening/Conclusie professioneel onderzoek/Verrichting (Onderzoek)">Verrichting (Onderzoek)</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)">Verrichting (Onderzoek)</div>
             </td>
             <td>
                <div>ClinicalImpression.investigation.item.extension:procedure</div>
@@ -6114,7 +5681,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6379,7 +5946,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1358</td>
             <td>
-               <div title="Zorgverlening/Informed Consent/Consentgever/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Consent.actor.reference</div>
@@ -6389,7 +5956,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6399,7 +5966,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1359</td>
             <td>
-               <div title="Zorgverlening/Informed Consent/Consentgever/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>Consent.consentingParty</div>
@@ -6409,7 +5976,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6499,7 +6066,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1364</td>
             <td>
-               <div title="Zorgverlening/Informed Consent/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>ntb</div>
@@ -6509,7 +6076,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6634,7 +6201,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1345</td>
             <td>
-               <div title="Zorgverlening/Patientbespreking/Deelnemer/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Encounter.participant.individual.extension:practitionerRole</div>
@@ -6644,7 +6211,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6657,7 +6224,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1990</td>
             <td>
-               <div title="Zorgverlening/Patientbespreking/Deelnemer/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>Encounter.participant.individual</div>
@@ -6667,7 +6234,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6680,7 +6247,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1989</td>
             <td>
-               <div title="Zorgverlening/Patientbespreking/Deelnemer/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Encounter.participant.individual.extension:patient</div>
@@ -6690,7 +6257,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -6749,7 +6316,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2685</td>
             <td>
-               <div title="Zorgverlening/Patientbespreking/Beleid/VoorgesteldeBehandeling/Verrichting">Verrichting</div>
+               <div title="Bouwstenen/Behandeling/Verrichting">Verrichting</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -7135,7 +6702,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3883</td>
             <td>
-               <div title="Zorgverlening/Vaccinatie/Toediener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Immunization.practitioner.actor</div>
@@ -7145,7 +6712,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7186,9 +6753,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7214,9 +6778,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7240,9 +6801,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7266,9 +6824,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7292,8 +6847,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7317,8 +6870,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7339,8 +6890,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7361,8 +6910,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7383,8 +6930,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7405,8 +6950,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7427,8 +6970,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7449,8 +6990,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7471,8 +7010,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7493,8 +7030,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7515,8 +7050,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7537,8 +7070,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7562,8 +7093,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7576,7 +7105,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2163</td>
             <td>
-               <div title="Zorgverlening/ZorgEpisode/ZorgEpisodeVerantwoordelijke/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -7586,9 +7115,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7609,8 +7136,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7634,8 +7159,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7940,7 +7463,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2128</td>
             <td>
-               <div title="Zorgverlening/ZorgTeam/ZorgTeamLid/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>CareTeam.participant.member</div>
@@ -7950,7 +7473,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7963,7 +7486,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1320</td>
             <td>
-               <div title="Zorgverlening/ZorgTeam/ZorgTeamLid/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>CareTeam.subject</div>
@@ -7973,7 +7496,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -7986,7 +7509,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1331</td>
             <td>
-               <div title="Zorgverlening/ZorgTeam/ZorgTeamLid/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>CareTeam.participant.member</div>
@@ -7996,7 +7519,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8009,7 +7532,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1337</td>
             <td>
-               <div title="Zorgverlening/ZorgTeam/ZorgTeamLid/TijdsInterval">TijdsInterval</div>
+               <div title="Bouwstenen/Subbouwstenen/TijdsInterval">TijdsInterval</div>
             </td>
             <td>
                <div>CareTeam.participant.period</div>
@@ -8019,7 +7542,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8124,7 +7647,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8802</td>
             <td>
-               <div title="Zorgverlening/IndividueelZorgplan/Casemanager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -8134,7 +7657,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8172,7 +7695,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8804</td>
             <td>
-               <div title="Zorgverlening/IndividueelZorgplan/Betrokkenen/ZorgTeam">ZorgTeam</div>
+               <div title="Zorgverlening/ZorgTeam">ZorgTeam</div>
             </td>
             <td>
                <div>CarePlan.careTeam</div>
@@ -8182,7 +7705,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8310,7 +7833,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8816</td>
             <td>
-               <div title="Zorgverlening/IndividueelZorgplan/ZorgAfspraak">ZorgAfspraak</div>
+               <div title="Zorgverlening/ZorgAfspraak">ZorgAfspraak</div>
             </td>
             <td>
                <div>CarePlan.basedOn</div>
@@ -8320,7 +7843,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8390,7 +7913,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8460,7 +7982,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8473,7 +7994,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9660</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Verwijzing van/ afkomstig van/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>ReferralRequest.requester.agent</div>
@@ -8483,8 +8004,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8520,7 +8040,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8882</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Verwijzing naar/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>ReferralRequest.recipient</div>
@@ -8530,7 +8050,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8812,7 +8332,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9139</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
+               <div title="Vrouw/Anamnese/Algemene anamnese/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -8822,7 +8342,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8832,7 +8352,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9143</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Verrichting (Algemene anamnese)">Verrichting (Algemene anamnese)</div>
+               <div title="Vrouw/Anamnese/Algemene anamnese/Verrichting (Algemene anamnese)">Verrichting (Algemene anamnese)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -8842,7 +8362,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8855,7 +8375,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9140</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
+               <div title="Zwangerschapsgegevens/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -8865,7 +8385,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8878,7 +8398,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9141</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Probleem (Psychiatrie)">Probleem (Psychiatrie)</div>
+               <div title="Vrouw/Anamnese/Psychische en/of Sociale problemen/Probleem (Psychiatrie)">Probleem (Psychiatrie)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -8888,7 +8408,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8898,7 +8418,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9142</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Probleem (Maternaal)">Probleem (Maternaal)</div>
+               <div title="Bevalling/Probleem (Maternaal)">Probleem (Maternaal)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -8908,7 +8428,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8918,7 +8438,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9144</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)">Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)</div>
+               <div title="Bevalling/Nageboortefase/Perineum/Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)">Inspectie perineum/ sfincter/ vrouwelijke geslachtsorganen (Observatie)</div>
             </td>
             <td>
                <div>Observation</div>
@@ -8941,7 +8461,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9661</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Probleem (Postpartum complicatie)">Probleem (Postpartum complicatie)</div>
+               <div title="Postnatale fase/Moeder/Probleem (Postpartum complicatie)">Probleem (Postpartum complicatie)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -8951,7 +8471,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8964,7 +8484,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9882</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Probleem (Kindspecifieke maternale problemen)">Probleem (Kindspecifieke maternale problemen)</div>
+               <div title="Bevalling/Uitdrijvingsfase/Probleem (Kindspecifieke maternale problemen)">Probleem (Kindspecifieke maternale problemen)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -8974,7 +8494,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -8987,7 +8507,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9880</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Verrichting (Zwangerschap)">Verrichting (Zwangerschap)</div>
+               <div title="Zwangerschapsgegevens/Verrichting (Zwangerschap)">Verrichting (Zwangerschap)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -8997,7 +8517,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9010,7 +8530,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9881</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Verrichting (Maternaal)">Verrichting (Maternaal)</div>
+               <div title="Bevalling/Verrichting (Maternaal)">Verrichting (Maternaal)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -9020,7 +8540,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9033,7 +8553,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9883</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Verrichting (Kindspecifieke maternale verrichtingen)">Verrichting (Kindspecifieke maternale verrichtingen)</div>
+               <div title="Bevalling/Uitdrijvingsfase/Verrichting (Kindspecifieke maternale verrichtingen)">Verrichting (Kindspecifieke maternale verrichtingen)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -9043,7 +8563,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9056,7 +8576,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9884</td>
             <td>
-               <div title="Zorgverlening/Verwijsgegevens/Reden van verwijzing/Verrichting (Postpartum complicatie)">Verrichting (Postpartum complicatie)</div>
+               <div title="Postnatale fase/Moeder/Verrichting (Postpartum complicatie)">Verrichting (Postpartum complicatie)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -9228,9 +8748,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9254,9 +8771,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9269,7 +8783,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1434</td>
             <td>
-               <div title="Vrouw/Demografische gegevens/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Patient</div>
@@ -9279,10 +8793,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9295,7 +8806,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10567</td>
             <td>
-               <div title="Vrouw/Demografische gegevens/JuridischeSituatie">JuridischeSituatie</div>
+               <div title="Administratief/JuridischeSituatie">JuridischeSituatie</div>
             </td>
             <td>
                <div>Condition</div>
@@ -9305,8 +8816,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9332,7 +8842,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9342,7 +8851,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-990</td>
             <td>
-               <div title="Vrouw/Demografische gegevens/Partner/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>RelatedPerson</div>
@@ -9352,8 +8861,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9363,7 +8871,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-7773</td>
             <td>
-               <div title="Vrouw/Demografische gegevens/Partner/Geboortedatum ">Geboortedatum</div>
+               <div title="Vrouw/Demografische gegevens/Partner/Geboortedatum">Geboortedatum</div>
             </td>
             <td>
                <div>RelatedPerson.birthDate</div>
@@ -9374,7 +8882,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9455,7 +8962,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9479,7 +8985,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9489,7 +8994,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2690</td>
             <td>
-               <div title="Vrouw/Demografische gegevens/Gezinssituatie/BurgerlijkeStaatRC">BurgerlijkeStaatRC</div>
+               <div title="Bouwstenen/Patienten context/BurgerlijkeStaatRC">BurgerlijkeStaatRC</div>
             </td>
             <td>
                <div>Patient.maritalStatus</div>
@@ -9500,7 +9005,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9524,7 +9028,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9545,7 +9048,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9566,7 +9068,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9587,7 +9088,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9608,7 +9108,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9629,7 +9128,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9650,7 +9148,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9671,7 +9168,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9692,7 +9188,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9713,7 +9208,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9734,7 +9228,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9755,7 +9248,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9779,7 +9271,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9803,7 +9294,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9827,7 +9317,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9851,7 +9340,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9864,7 +9352,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2910</td>
             <td>
-               <div title="Vrouw/Demografische gegevens/Taalvaardigheid">Taalvaardigheid</div>
+               <div title="Bouwstenen/Patienten context/Taalvaardigheid">Taalvaardigheid</div>
             </td>
             <td>
                <div>Patient.communication.extension:languageProficiency</div>
@@ -9874,8 +9362,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..* C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9899,7 +9386,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9923,7 +9409,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9947,7 +9432,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9971,7 +9455,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -9992,7 +9475,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10013,7 +9495,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10034,7 +9515,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10228,7 +9708,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10432</td>
             <td>
-               <div title="Vrouw/BehandelAanwijzing/Wilsverklaring/Wilsverklaring">Wilsverklaring</div>
+               <div title="Bouwstenen/Patienten context/Wilsverklaring">Wilsverklaring</div>
             </td>
             <td>
                <div>Consent</div>
@@ -10294,7 +9774,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10418</td>
             <td>
-               <div title="Vrouw/BehandelAanwijzing/AfspraakPartij/Patient/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Patient</div>
@@ -10304,7 +9784,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10340,7 +9820,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10419</td>
             <td>
-               <div title="Vrouw/BehandelAanwijzing/AfspraakPartij/Vertegenwoordiger/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>RelatedPerson</div>
@@ -10350,7 +9830,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10383,7 +9863,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10420</td>
             <td>
-               <div title="Vrouw/BehandelAanwijzing/AfspraakPartij/Zorgverlener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -10393,7 +9873,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10469,7 +9949,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1675</td>
             <td>
-               <div title="Vrouw/Betrokken zorgverlener/ zorginstelling/Huisarts/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Patient.generalPractitioner</div>
@@ -10479,7 +9959,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10515,7 +9995,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1677</td>
             <td>
-               <div title="Vrouw/Betrokken zorgverlener/ zorginstelling/Apotheek/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -10525,7 +10005,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10558,7 +10038,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1681</td>
             <td>
-               <div title="Vrouw/Betrokken zorgverlener/ zorginstelling/Specialist/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>CareTeam.participant.member</div>
@@ -10568,7 +10048,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10604,7 +10084,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2692</td>
             <td>
-               <div title="Vrouw/Betrokken zorgverlener/ zorginstelling/Specialist/Reden betrokkenheid/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
+               <div title="Vrouw/Anamnese/Algemene anamnese/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -10614,7 +10094,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10624,7 +10104,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2731</td>
             <td>
-               <div title="Vrouw/Betrokken zorgverlener/ zorginstelling/Specialist/Reden betrokkenheid/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
+               <div title="Zwangerschapsgegevens/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -10634,7 +10114,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10647,7 +10127,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3196</td>
             <td>
-               <div title="Vrouw/Betrokken zorgverlener/ zorginstelling/Specialist/Reden betrokkenheid/Probleem (Maternaal)">Probleem (Maternaal)</div>
+               <div title="Bevalling/Probleem (Maternaal)">Probleem (Maternaal)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -10657,7 +10137,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10911,7 +10391,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10932,14 +10411,12 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-916</td>
             <td>
@@ -10954,7 +10431,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10975,7 +10451,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -10996,7 +10471,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11017,7 +10491,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11038,7 +10511,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11059,7 +10531,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11080,7 +10551,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11101,7 +10571,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11122,7 +10591,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11143,7 +10611,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11164,7 +10631,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11185,7 +10651,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11206,7 +10671,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11227,7 +10691,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11248,7 +10711,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11269,7 +10731,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11279,7 +10740,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1097</td>
             <td>
-               <div title="Vrouw/Anamnese/Algemene anamnese/Verrichting (Algemene anamnese)/Indicatie/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
+               <div title="Vrouw/Anamnese/Algemene anamnese/Probleem (Algemene anamnese)">Probleem (Algemene anamnese)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -11290,7 +10751,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11311,7 +10771,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11332,7 +10791,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11356,7 +10814,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11380,7 +10837,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11404,7 +10860,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11425,7 +10880,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11435,7 +10889,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10389</td>
             <td>
-               <div title="Vrouw/Anamnese/Algemene anamnese/Verrichting (Algemene anamnese)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -11445,8 +10899,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11467,7 +10920,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11477,7 +10929,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10390</td>
             <td>
-               <div title="Vrouw/Anamnese/Algemene anamnese/Verrichting (Algemene anamnese)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -11487,8 +10939,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11509,7 +10960,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11519,7 +10969,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10391</td>
             <td>
-               <div title="Vrouw/Anamnese/Algemene anamnese/Verrichting (Algemene anamnese)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -11529,8 +10979,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11551,7 +11000,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11561,7 +11009,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10392</td>
             <td>
-               <div title="Vrouw/Anamnese/Algemene anamnese/Verrichting (Algemene anamnese)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -11571,8 +11019,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11593,7 +11040,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11637,7 +11083,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11658,7 +11103,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11679,7 +11123,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11700,7 +11143,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11721,7 +11163,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11742,7 +11183,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11763,7 +11203,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11784,7 +11223,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11805,7 +11243,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11826,7 +11263,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11847,7 +11283,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11868,7 +11303,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11889,7 +11323,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11910,7 +11343,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11931,7 +11363,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11952,7 +11383,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11973,7 +11403,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -11994,7 +11423,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12015,7 +11443,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12036,7 +11463,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12057,7 +11483,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12078,7 +11503,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12099,7 +11523,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12120,7 +11543,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12141,7 +11563,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12162,7 +11583,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12186,7 +11606,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12210,7 +11629,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12234,7 +11652,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12258,7 +11675,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12282,7 +11698,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12303,7 +11718,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12324,7 +11738,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12876,11 +12289,10 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-3357</td>
             <td>
-               <div title="Vrouw/Metingen/Lichaamsgewicht">Lichaamsgewicht</div>
+               <div title="Bouwstenen/Metingen/Lichaamsgewicht">Lichaamsgewicht</div>
             </td>
             <td>
                <div>Observation.value[x]:valueQuantity</div>
@@ -12890,7 +12302,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -12900,7 +12312,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1672</td>
             <td>
-               <div title="Vrouw/Metingen/Lichaamslengte">Lichaamslengte</div>
+               <div title="Bouwstenen/Metingen/Lichaamslengte">Lichaamslengte</div>
             </td>
             <td>
                <div>Observation.value[x]:valueQuantity</div>
@@ -12910,7 +12322,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13078,7 +12490,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1139</td>
             <td>
-               <div title="Prullenbak/Bloedonderzoek/LaboratoriumTest_Bloedgroep">LaboratoriumTest_Bloedgroep</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/PSIE/LaboratoriumTest_Bloedgroep">LaboratoriumTest_Bloedgroep</div>
             </td>
             <td>
                <div>Observation.value[x]:valueCodeableConcept</div>
@@ -13088,7 +12500,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
+                  <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13098,7 +12510,27 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1151</td>
             <td>
-               <div title="Prullenbak/Bloedonderzoek/LaboratoriumTest_Rhesus D">LaboratoriumTest_Rhesus D</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/PSIE/LaboratoriumTest_Rhesus D">LaboratoriumTest_Rhesus D</div>
+            </td>
+            <td>
+               <div>Observation.value[x]:valueCodeableConcept</div>
+            </td>
+            <td>
+               <div>zib-LaboratoryTestResult-Observation</div>
+            </td>
+            <td>
+               <ul>
+                  <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
+               </ul>
+            </td>
+            <td>
+               <span style="font-style: italic;">No mappings</span>
+            </td>
+         </tr>
+         <tr class="row-valid">
+            <td>peri32-dataelement-1163</td>
+            <td>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/PSIE/LaboratoriumTest_Rhesus c">LaboratoriumTest_Rhesus c</div>
             </td>
             <td>
                <div>Observation.value[x]:valueCodeableConcept</div>
@@ -13116,71 +12548,51 @@
             </td>
          </tr>
          <tr class="row-valid">
-            <td>peri32-dataelement-1163</td>
+            <td>peri32-dataelement-4193</td>
             <td>
-               <div title="Prullenbak/Bloedonderzoek/LaboratoriumTest_Rhesus c">LaboratoriumTest_Rhesus c</div>
+               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie)">Werkelijke plaats baring (type locatie) (Observatie)</div>
             </td>
             <td>
-               <div>Observation.value[x]:valueCodeableConcept</div>
+               <div>Observation</div>
             </td>
             <td>
-               <div>zib-LaboratoryTestResult-Observation</div>
+               <div>bc-BirthObservation</div>
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
+                  <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
-               <span style="font-style: italic;">No mappings</span>
+               <ul>
+                  <li>Mapping <span>bc-BirthObservation</span> - path <span>Observation</span>
+                  </li>
+               </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
+         <tr class="row-valid">
+            <td>peri32-dataelement-1587</td>
+            <td>
+               <div title="Bevalling/Uitdrijvingsfase/Ziekenhuis baring">Ziekenhuis baring</div>
+            </td>
+            <td>
+               <div>Observation</div>
+            </td>
+            <td>
+               <div>bc-DeliveryObservation</div>
+            </td>
+            <td>
+               <ul>
+                  <li>0..1 C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
+               </ul>
+            </td>
+            <td>
+               <ul>
+                  <li>Mapping <span>bc-DeliveryProcedure</span> - path <span>Procedure.location</span>
+                  </li>
+               </ul>
+            </td>
+         </tr>
          <tr class="row-valid">
             <td>peri32-dataelement-2902</td>
             <td>
@@ -13195,7 +12607,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13205,7 +12616,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2911</td>
             <td>
-               <div title="Gezin/Taalvaardigheid">Taalvaardigheid</div>
+               <div title="Bouwstenen/Patienten context/Taalvaardigheid">Taalvaardigheid</div>
             </td>
             <td>
                <div>Patient.communication.extension:languageProficiency</div>
@@ -13216,7 +12627,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13240,7 +12650,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13264,7 +12673,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13288,7 +12696,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13312,7 +12719,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13336,7 +12742,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13360,7 +12765,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13407,7 +12811,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13415,217 +12818,6 @@
                   <li>Mapping <span>bc-FamilySituationAssessment</span> - path <span>Observation.comment</span>
                   </li>
                </ul>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10556</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin">Probleem infectieziekte(n) Gezin</div>
-            </td>
-            <td>
-               <div>FamilyMemberHistory.condition.code</div>
-            </td>
-            <td>
-               <div>bc-FamilyMemberHistory</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-FamilyMemberHistory</span> - path <span>FamilyMemberHistory.condition.code</span>
-                  </li>
-               </ul>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10557</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/ProbleemAnatomischeLocatie">ProbleemAnatomischeLocatie</div>
-            </td>
-            <td>
-               <div>Condition.bodySite</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10558</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/ProbleemLateraliteit">ProbleemLateraliteit</div>
-            </td>
-            <td>
-               <div>Condition.bodySite.extension:Laterality.value[x]:valueCodeableConcept</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10559</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/ProbleemType">ProbleemType</div>
-            </td>
-            <td>
-               <div>Condition.category</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10560</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/ProbleemNaam">ProbleemNaam</div>
-            </td>
-            <td>
-               <div>Condition.code</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10561</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/ProbleemBeginDatum">ProbleemBeginDatum</div>
-            </td>
-            <td>
-               <div>Condition.onset[x]:onsetDateTime</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10562</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/ProbleemEindDatum">ProbleemEindDatum</div>
-            </td>
-            <td>
-               <div>Condition.abatement[x]:abatementDateTime</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10563</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/ProbleemStatus">ProbleemStatus</div>
-            </td>
-            <td>
-               <div>Condition.clinicalStatus</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10564</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/VerificatieStatus">VerificatieStatus</div>
-            </td>
-            <td>
-               <div>Condition.verificationStatus</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10565</td>
-            <td>
-               <div title="Gezin/Probleem infectieziekte(n) Gezin/Toelichting">Toelichting</div>
-            </td>
-            <td>
-               <div>Condition.note</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
          <tr class="row-valid">
@@ -13642,9 +12834,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13691,7 +12880,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13715,7 +12903,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13728,7 +12915,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9662</td>
             <td>
-               <div title="Zwangerschapsgegevens/Coördinerend zorgverlener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -13738,8 +12925,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13760,9 +12946,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13783,8 +12966,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13805,9 +12986,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13828,9 +13006,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13851,7 +13026,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13872,8 +13046,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13897,8 +13069,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13922,8 +13092,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13947,8 +13115,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13972,7 +13138,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -13993,7 +13158,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14017,7 +13181,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14041,7 +13204,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14065,7 +13227,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14089,7 +13250,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14113,7 +13273,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14137,7 +13296,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14161,7 +13319,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14185,7 +13342,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14195,7 +13351,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1833</td>
             <td>
@@ -14210,7 +13365,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14234,7 +13388,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14258,7 +13411,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14282,7 +13434,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14306,7 +13457,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14330,7 +13480,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14354,7 +13503,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14378,7 +13526,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14402,7 +13549,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14426,7 +13572,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14450,7 +13595,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14474,7 +13618,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14498,7 +13641,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14522,7 +13664,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14535,7 +13676,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1745</td>
             <td>
-               <div title="Zwangerschapsgegevens/Foliumzuurgebruik (Observatie)/FoliumzuurgebruikWaarde ">FoliumzuurgebruikWaarde</div>
+               <div title="Zwangerschapsgegevens/Foliumzuurgebruik (Observatie)/FoliumzuurgebruikWaarde">FoliumzuurgebruikWaarde</div>
             </td>
             <td>
                <div>Observation.value[x]:valueCodeableConcept</div>
@@ -14546,7 +13687,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14570,7 +13710,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14594,7 +13733,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14848,7 +13986,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14864,7 +14001,7 @@
                <div title="Zwangerschapsgegevens/Voornemens vrouw/Voorgenomen plaats baring tijdens zwangerschap (Observatie)">Voorgenomen plaats baring tijdens zwangerschap (Observatie)</div>
             </td>
             <td>
-               <div>Observation.value[x]:valueCodeableConcept</div>
+               <div>Observation</div>
             </td>
             <td>
                <div>bc-MaternalObservation</div>
@@ -14872,12 +14009,11 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <ul>
-                  <li>Mapping <span>bc-MaternalObservation</span> - path <span>Observation.value[x]:valueCodeableConcept</span>
+                  <li>Mapping <span>bc-MaternalObservation</span> - path <span>Observation</span>
                   </li>
                </ul>
             </td>
@@ -14896,7 +14032,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14920,7 +14055,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14944,7 +14078,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -14957,7 +14090,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2271</td>
             <td>
-               <div title="Zwangerschapsgegevens/Voornemens vrouw/Voorgenomen plaats baring tijdens zwangerschap (Observatie)/Voorkeursziekenhuis/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -14967,15 +14100,13 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2257</td>
             <td>
@@ -15127,8 +14258,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15152,7 +14282,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15176,7 +14305,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15223,7 +14351,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15239,7 +14366,7 @@
                <div title="Zwangerschapsgegevens/Voornemens vrouw/Voorgenomen achternaam (Observatie)">Voorgenomen achternaam (Observatie)</div>
             </td>
             <td>
-               <div>Observation.value[x]:valueString</div>
+               <div>Observation</div>
             </td>
             <td>
                <div>bc-MaternalObservation</div>
@@ -15251,7 +14378,7 @@
             </td>
             <td>
                <ul>
-                  <li>Mapping <span>bc-MaternalObservation</span> - path <span>Observation.value[x]:valueString</span>
+                  <li>Mapping <span>bc-MaternalObservation</span> - path <span>Observation</span>
                   </li>
                </ul>
             </td>
@@ -15348,7 +14475,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2151</td>
             <td>
@@ -15372,7 +14498,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8944</td>
             <td>
-               <div title="Zwangerschapsgegevens/Voornemens vrouw/Bevalplan/Media">Media</div>
+               <div title="Medisch onderzoek/Media">Media</div>
             </td>
             <td>
                <div>Binary</div>
@@ -15382,7 +14508,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15403,7 +14529,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15416,7 +14541,7 @@
                <div title="Zwangerschapsgegevens/Kraamzorg/Kraamzorg aangevraagd (Observatie)">Kraamzorg aangevraagd (Observatie)</div>
             </td>
             <td>
-               <div>Observation.value[x]:valueBoolean</div>
+               <div>Observation</div>
             </td>
             <td>
                <div>bc-MaternalObservation</div>
@@ -15428,7 +14553,7 @@
             </td>
             <td>
                <ul>
-                  <li>Mapping <span>bc-MaternalObservation</span> - path <span>Observation.value[x]:valueBoolean</span>
+                  <li>Mapping <span>bc-MaternalObservation</span> - path <span>Observation</span>
                   </li>
                </ul>
             </td>
@@ -15482,7 +14607,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2270</td>
             <td>
-               <div title="Zwangerschapsgegevens/Kraamzorg/Kraamzorg aangevraagd (Observatie)/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Observation.value[x].extension:valueReference</div>
@@ -15492,7 +14617,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15562,7 +14687,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15575,7 +14699,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10743</td>
             <td>
-               <div title="Zwangerschapsgegevens/Kraamzorg/KraamzorgIntake/Contact">Contact</div>
+               <div title="Administratief/Contact">Contact</div>
             </td>
             <td>
                <div>Encounter</div>
@@ -15585,8 +14709,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15610,7 +14733,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15634,7 +14756,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15658,7 +14779,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15682,7 +14802,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15706,7 +14825,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15730,7 +14848,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15754,7 +14871,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15778,7 +14894,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15802,8 +14917,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15816,7 +14929,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10520</td>
             <td>
-               <div title="Zwangerschapsgegevens/Prenatale controle/Contact">Contact</div>
+               <div title="Administratief/Contact">Contact</div>
             </td>
             <td>
                <div>Encounter</div>
@@ -15826,9 +14939,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15852,7 +14963,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15873,7 +14983,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15897,7 +15006,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15921,7 +15029,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15945,7 +15052,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15969,7 +15075,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -15982,7 +15087,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1078</td>
             <td>
-               <div title="Zwangerschapsgegevens/Prenatale controle/Lichaamsgewicht">Lichaamsgewicht</div>
+               <div title="Bouwstenen/Metingen/Lichaamsgewicht">Lichaamsgewicht</div>
             </td>
             <td>
                <div>Observation</div>
@@ -15992,8 +15097,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16003,7 +15107,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1072</td>
             <td>
-               <div title="Zwangerschapsgegevens/Prenatale controle/Bloeddruk">Bloeddruk</div>
+               <div title="Bouwstenen/Metingen/Bloeddruk">Bloeddruk</div>
             </td>
             <td>
                <div>Observation</div>
@@ -16013,8 +15117,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16035,8 +15138,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16057,8 +15158,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16079,8 +15178,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16101,8 +15198,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16123,8 +15218,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16145,8 +15238,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16167,8 +15258,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16189,8 +15278,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16211,8 +15298,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16233,8 +15318,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16255,8 +15338,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16277,8 +15358,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16299,8 +15378,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16321,8 +15398,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16343,8 +15418,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16365,8 +15438,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16387,8 +15458,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16409,8 +15478,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16431,8 +15498,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16453,8 +15518,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16475,8 +15538,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16497,8 +15558,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16519,8 +15578,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16541,8 +15598,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16563,8 +15618,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16585,8 +15638,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16607,8 +15658,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16632,7 +15681,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16656,7 +15704,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16680,7 +15727,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16704,7 +15750,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16728,7 +15773,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16752,7 +15796,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16776,7 +15819,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16800,7 +15842,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16824,7 +15865,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16848,7 +15888,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16872,7 +15911,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16898,7 +15936,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16922,7 +15959,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16946,7 +15982,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16970,7 +16005,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -16994,7 +16028,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17018,7 +16051,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17042,7 +16074,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17066,7 +16097,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17113,7 +16143,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17137,7 +16166,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17184,7 +16212,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17208,7 +16235,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17232,7 +16258,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17256,7 +16281,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17303,7 +16327,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17327,7 +16350,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17374,7 +16396,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17398,7 +16419,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17422,7 +16442,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17446,7 +16465,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17470,7 +16488,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17494,7 +16511,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17518,7 +16534,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17542,7 +16557,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17566,7 +16580,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17705,8 +16718,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17730,8 +16741,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17755,8 +16764,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17780,8 +16787,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17805,8 +16810,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17830,8 +16833,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17855,8 +16856,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17880,8 +16879,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17905,8 +16902,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17930,8 +16925,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17952,8 +16945,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -17977,8 +16968,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18002,8 +16991,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18027,7 +17014,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18051,7 +17037,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18075,7 +17060,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18099,7 +17083,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18120,7 +17103,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18144,7 +17126,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18168,7 +17149,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18181,7 +17161,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1207</td>
             <td>
-               <div title="Zwangerschapsgegevens/Verrichting (Zwangerschap)/Indicatie/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
+               <div title="Zwangerschapsgegevens/Probleem (Zwangerschap)">Probleem (Zwangerschap)</div>
             </td>
             <td>
                <div>Procedure.reasonReference</div>
@@ -18191,8 +17171,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18216,7 +17195,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18240,7 +17218,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18264,7 +17241,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18277,7 +17253,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10433</td>
             <td>
-               <div title="Zwangerschapsgegevens/Verrichting (Zwangerschap)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -18287,8 +17263,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18309,7 +17284,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18322,7 +17296,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1312</td>
             <td>
-               <div title="Zwangerschapsgegevens/Verrichting (Zwangerschap)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Procedure.performer</div>
@@ -18332,8 +17306,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18357,7 +17330,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18370,7 +17342,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1310</td>
             <td>
-               <div title="Zwangerschapsgegevens/Verrichting (Zwangerschap)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Procedure.performer</div>
@@ -18380,8 +17352,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18405,7 +17376,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18415,7 +17385,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1311</td>
             <td>
-               <div title="Zwangerschapsgegevens/Verrichting (Zwangerschap)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>ProcedureRequest.requester</div>
@@ -18425,8 +17395,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18508,10 +17477,10 @@
                <div title="Zwangerschapsgegevens/Maternale sterfte">Maternale sterfte</div>
             </td>
             <td>
-               <div>Observation</div>
+               <div>Patient</div>
             </td>
             <td>
-               <div>bc-MaternalObservation</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
@@ -18519,10 +17488,7 @@
                </ul>
             </td>
             <td>
-               <ul>
-                  <li>Mapping <span>bc-MaternalObservation</span> - path <span>Observation</span>
-                  </li>
-               </ul>
+               <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
          <tr class="row-valid">
@@ -18531,10 +17497,10 @@
                <div title="Zwangerschapsgegevens/Maternale sterfte/OverlijdensIndicator">OverlijdensIndicator</div>
             </td>
             <td>
-               <div>Observation.value[x]:valueBoolean</div>
+               <div>Patient.deceased[x]</div>
             </td>
             <td>
-               <div>bc-PregnancyObservation</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
@@ -18542,10 +17508,7 @@
                </ul>
             </td>
             <td>
-               <ul>
-                  <li>Mapping <span>bc-PregnancyObservation</span> - path <span>Observation.value[x]:valueBoolean</span>
-                  </li>
-               </ul>
+               <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
          <tr class="row-valid">
@@ -18554,10 +17517,10 @@
                <div title="Zwangerschapsgegevens/Maternale sterfte/DatumOverlijden">DatumOverlijden</div>
             </td>
             <td>
-               <div>Observation.value[x]:valueDateTime</div>
+               <div>Patient.deceased[x]</div>
             </td>
             <td>
-               <div>bc-PregnancyObservation</div>
+               <div>nl-core-patient</div>
             </td>
             <td>
                <ul>
@@ -18565,16 +17528,13 @@
                </ul>
             </td>
             <td>
-               <ul>
-                  <li>Mapping <span>bc-PregnancyObservation</span> - path <span>Observation.value[x]:valueDateTime</span>
-                  </li>
-               </ul>
+               <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
          <tr class="row-valid">
             <td>peri32-dataelement-3881</td>
             <td>
-               <div title="Zwangerschapsgegevens/Conclusie professioneel onderzoek">Conclusie professioneel onderzoek</div>
+               <div title="Zorgverlening/Conclusie professioneel onderzoek">Conclusie professioneel onderzoek</div>
             </td>
             <td>
                <div>ClinicalImpression</div>
@@ -18617,7 +17577,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10550</td>
             <td>
-               <div title="Zwangerschapsgegevens/Bijlage/Media">Media</div>
+               <div title="Medisch onderzoek/Media">Media</div>
             </td>
             <td>
                <div>Binary</div>
@@ -18627,7 +17587,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18729,7 +17689,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10908</td>
             <td>
-               <div title="Counseling prenatale screening en prenatale diagnostiek/Conclusie professioneel onderzoek/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>ClinicalImpression.assessor</div>
@@ -18739,7 +17699,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18752,7 +17712,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10909</td>
             <td>
-               <div title="Counseling prenatale screening en prenatale diagnostiek/Conclusie professioneel onderzoek/Verrichting (Onderzoek)">Verrichting (Onderzoek)</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)">Verrichting (Onderzoek)</div>
             </td>
             <td>
                <div>ClinicalImpression.investigation.item.extension:procedure</div>
@@ -18762,7 +17722,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18878,8 +17838,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18903,7 +17861,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18927,7 +17884,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18948,7 +17904,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18972,7 +17927,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -18996,7 +17950,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19020,7 +17973,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19044,7 +17996,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19068,7 +18019,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19092,7 +18042,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19116,7 +18065,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19140,7 +18088,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19161,7 +18108,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19185,7 +18131,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19209,7 +18154,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19233,7 +18177,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19257,7 +18200,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19281,7 +18223,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19305,7 +18246,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19326,7 +18266,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19350,7 +18289,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19374,7 +18312,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19387,7 +18324,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1583</td>
             <td>
-               <div title="Bevalling/Verrichting (Maternaal)/Indicatie/Probleem (Maternaal)">Probleem (Maternaal)</div>
+               <div title="Bevalling/Probleem (Maternaal)">Probleem (Maternaal)</div>
             </td>
             <td>
                <div>Procedure.reasonReference</div>
@@ -19397,8 +18334,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19422,7 +18358,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19446,7 +18381,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19470,7 +18404,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19494,7 +18427,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19507,7 +18439,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10434</td>
             <td>
-               <div title="Bevalling/Verrichting (Maternaal)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -19517,8 +18449,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19539,7 +18470,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19552,7 +18482,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10435</td>
             <td>
-               <div title="Bevalling/Verrichting (Maternaal)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -19562,8 +18492,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19584,7 +18513,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19597,7 +18525,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10436</td>
             <td>
-               <div title="Bevalling/Verrichting (Maternaal)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -19607,8 +18535,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19629,7 +18556,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19639,7 +18565,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10438</td>
             <td>
-               <div title="Bevalling/Verrichting (Maternaal)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -19649,8 +18575,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19660,7 +18585,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3882</td>
             <td>
-               <div title="Bevalling/Conclusie professioneel onderzoek">Conclusie professioneel onderzoek</div>
+               <div title="Zorgverlening/Conclusie professioneel onderzoek">Conclusie professioneel onderzoek</div>
             </td>
             <td>
                <div>ClinicalImpression</div>
@@ -19670,7 +18595,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19694,8 +18619,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19716,8 +18639,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19741,8 +18662,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19766,8 +18685,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19791,7 +18708,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19812,8 +18728,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19837,8 +18751,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19862,8 +18774,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19887,8 +18797,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19912,8 +18820,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19937,8 +18843,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19962,8 +18866,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -19987,7 +18889,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20011,7 +18912,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20035,7 +18935,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20059,7 +18958,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20083,7 +18981,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20107,7 +19004,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20131,7 +19027,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20155,7 +19050,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20179,7 +19073,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20203,7 +19096,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20227,8 +19119,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20241,7 +19131,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9685</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Patient</div>
@@ -20251,9 +19141,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20412,8 +19300,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20437,8 +19323,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20462,8 +19346,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20487,8 +19369,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20512,8 +19392,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20523,11 +19401,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-4169</td>
             <td>
@@ -20644,34 +19517,9 @@
             </td>
          </tr>
          <tr class="row-valid">
-            <td>peri32-dataelement-4193</td>
-            <td>
-               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie) ">Werkelijke plaats baring (type locatie) (Observatie)</div>
-            </td>
-            <td>
-               <div>Observation</div>
-            </td>
-            <td>
-               <div>bc-BirthObservation</div>
-            </td>
-            <td>
-               <ul>
-                  <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-BirthObservation</span> - path <span>Observation</span>
-                  </li>
-               </ul>
-            </td>
-         </tr>
-         <tr class="row-valid">
             <td>peri32-dataelement-4194</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie) /ObservatieDatumTijd">ObservatieDatumTijd</div>
+               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie)/ObservatieDatumTijd">ObservatieDatumTijd</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectiveDateTime</div>
@@ -20682,8 +19530,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20696,7 +19542,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-4196</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie) /WerkelijkePlaatsBaringWaarde">WerkelijkePlaatsBaringWaarde</div>
+               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie)/WerkelijkePlaatsBaringWaarde">WerkelijkePlaatsBaringWaarde</div>
             </td>
             <td>
                <div>Observation.value[x]:valueCodeableConcept</div>
@@ -20707,8 +19553,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20721,7 +19565,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-4197</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie) /ObservatieMethode">ObservatieMethode</div>
+               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie)/ObservatieMethode">ObservatieMethode</div>
             </td>
             <td>
                <div>Observation.method</div>
@@ -20732,8 +19576,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20746,7 +19588,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-4204</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie) /Toelichting">Toelichting</div>
+               <div title="Bevalling/Uitdrijvingsfase/Werkelijke plaats baring (type locatie) (Observatie)/Toelichting">Toelichting</div>
             </td>
             <td>
                <div>Observation.comment</div>
@@ -20757,8 +19599,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20769,33 +19609,9 @@
             </td>
          </tr>
          <tr class="row-valid">
-            <td>peri32-dataelement-1587</td>
-            <td>
-               <div title="Bevalling/Uitdrijvingsfase/Ziekenhuis baring">Ziekenhuis baring</div>
-            </td>
-            <td>
-               <div>Procedure.location</div>
-            </td>
-            <td>
-               <div>bc-DeliveryProcedure</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-DeliveryProcedure</span> - path <span>Procedure.location</span>
-                  </li>
-               </ul>
-            </td>
-         </tr>
-         <tr class="row-valid">
             <td>peri32-dataelement-1588</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Ziekenhuis baring/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -20805,25 +19621,13 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1591</td>
             <td>
@@ -20838,7 +19642,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20862,7 +19665,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20886,7 +19688,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20910,7 +19711,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20934,7 +19734,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20958,7 +19757,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -20982,7 +19780,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21006,7 +19803,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21030,7 +19826,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21054,7 +19849,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21078,7 +19872,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21102,7 +19895,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21126,7 +19918,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21150,7 +19941,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21174,7 +19964,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21198,7 +19987,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21211,7 +19999,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1620</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Verrichting (Kindspecifieke maternale verrichtingen)/Indicatie/Probleem (Kindspecifieke maternale problemen)">Probleem (Kindspecifieke maternale problemen)</div>
+               <div title="Bevalling/Uitdrijvingsfase/Probleem (Kindspecifieke maternale problemen)">Probleem (Kindspecifieke maternale problemen)</div>
             </td>
             <td>
                <div>Procedure.reasonReference</div>
@@ -21221,8 +20009,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21246,7 +20033,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21270,7 +20056,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21294,7 +20079,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21318,7 +20102,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21331,7 +20114,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10452</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Verrichting (Kindspecifieke maternale verrichtingen)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -21341,8 +20124,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21363,7 +20145,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21376,7 +20157,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10453</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Verrichting (Kindspecifieke maternale verrichtingen)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -21386,8 +20167,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21408,7 +20188,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21421,7 +20200,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10454</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Verrichting (Kindspecifieke maternale verrichtingen)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -21431,8 +20210,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21453,7 +20231,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21463,7 +20240,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10457</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Verrichting (Kindspecifieke maternale verrichtingen)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -21473,8 +20250,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21504,11 +20280,10 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1625</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Aanpakker kind/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Encounter.participant.individual</div>
@@ -21518,7 +20293,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21554,7 +20329,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1627</td>
             <td>
-               <div title="Bevalling/Uitdrijvingsfase/Supervisor/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Encounter.participant.individual</div>
@@ -21564,7 +20339,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21588,7 +20363,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21756,7 +20530,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1438</td>
             <td>
-               <div title="Bevalling/Nageboortefase/Perineum/Verrichting/Indicatie/Probleem (2017)">Probleem</div>
+               <div title="Bouwstenen/Behandeling/Probleem (2017)">Probleem</div>
             </td>
             <td>
                <div>Condition</div>
@@ -21766,7 +20540,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21845,7 +20619,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1442</td>
             <td>
-               <div title="Bevalling/Nageboortefase/Perineum/Verrichting/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -21855,7 +20629,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -21886,26 +20660,6 @@
             </td>
          </tr>
          <tr class="row-valid">
-            <td>peri31-dataelement-1444</td>
-            <td>
-               <div title="Bevalling/Nageboortefase/Perineum/Verrichting/Locatie/Zorgaanbieder">Zorgaanbieder</div>
-            </td>
-            <td>
-               <div>Organization</div>
-            </td>
-            <td>
-               <div>nl-core-organization</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
             <td>peri31-dataelement-1445</td>
             <td>
                <div title="Bevalling/Nageboortefase/Perineum/Verrichting/Uitvoerder">Uitvoerder</div>
@@ -21929,26 +20683,6 @@
             </td>
          </tr>
          <tr class="row-valid">
-            <td>peri31-dataelement-1446</td>
-            <td>
-               <div title="Bevalling/Nageboortefase/Perineum/Verrichting/Uitvoerder/Zorgverlener">Zorgverlener</div>
-            </td>
-            <td>
-               <div>Practitioner</div>
-            </td>
-            <td>
-               <div>nl-core-practitioner</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
             <td>peri31-dataelement-1447</td>
             <td>
                <div title="Bevalling/Nageboortefase/Perineum/Verrichting/Aanvrager">Aanvrager</div>
@@ -21958,26 +20692,6 @@
             </td>
             <td>
                <div>zib-ProcedureRequest</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri31-dataelement-1448</td>
-            <td>
-               <div title="Bevalling/Nageboortefase/Perineum/Verrichting/Aanvrager/Zorgverlener">Zorgverlener</div>
-            </td>
-            <td>
-               <div>Practitioner</div>
-            </td>
-            <td>
-               <div>nl-core-practitioner</div>
             </td>
             <td>
                <ul>
@@ -22002,7 +20716,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22150,7 +20863,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1455</td>
             <td>
-               <div title="Bevalling/Nageboortefase/Placenta/Verrichting/Indicatie/Probleem (2017)">Probleem</div>
+               <div title="Bouwstenen/Behandeling/Probleem (2017)">Probleem</div>
             </td>
             <td>
                <div>Condition</div>
@@ -22160,7 +20873,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22236,7 +20949,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1459</td>
             <td>
-               <div title="Bevalling/Nageboortefase/Placenta/Verrichting/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -22246,7 +20959,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22276,7 +20989,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1461</td>
             <td>
-               <div title="Bevalling/Nageboortefase/Placenta/Verrichting/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -22286,7 +20999,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22316,7 +21029,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1463</td>
             <td>
-               <div title="Bevalling/Nageboortefase/Placenta/Verrichting/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -22326,7 +21039,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22356,7 +21069,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1465</td>
             <td>
-               <div title="Bevalling/Nageboortefase/Placenta/Verrichting/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -22366,7 +21079,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22387,7 +21100,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22411,7 +21123,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22435,7 +21146,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22459,7 +21169,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22483,7 +21192,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22507,7 +21215,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22531,7 +21238,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22555,7 +21261,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22579,7 +21284,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22603,7 +21307,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22627,7 +21330,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22651,7 +21353,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22675,7 +21376,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22699,7 +21399,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -22723,7 +21422,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23368,7 +22066,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23392,7 +22089,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23416,7 +22112,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23440,7 +22135,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23464,7 +22158,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23488,7 +22181,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23498,7 +22190,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10269</td>
             <td>
-               <div title="Bevalling/Opname en Ontslag/Contact">Contact</div>
+               <div title="Administratief/Contact">Contact</div>
             </td>
             <td>
                <div>Encounter</div>
@@ -23508,8 +22200,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23567,7 +22258,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10805</td>
             <td>
-               <div title="Foetus/Demografische gegevens/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Patient</div>
@@ -23577,7 +22268,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23587,7 +22278,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1404</td>
             <td>
@@ -23602,8 +22292,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23627,8 +22315,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23641,7 +22327,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1378</td>
             <td>
-               <div title="Kind/Demografische gegevens/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Patient</div>
@@ -23651,9 +22337,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23668,7 +22352,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10566</td>
             <td>
-               <div title="Kind/Demografische gegevens/JuridischeSituatie">JuridischeSituatie</div>
+               <div title="Administratief/JuridischeSituatie">JuridischeSituatie</div>
             </td>
             <td>
                <div>Condition</div>
@@ -23678,8 +22362,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23694,7 +22377,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1405</td>
             <td>
-               <div title="Kind/Demografische gegevens/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>RelatedPerson</div>
@@ -23704,7 +22387,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23725,7 +22408,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23746,7 +22428,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23767,7 +22448,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23777,7 +22457,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10499</td>
             <td>
-               <div title="Kind/Demografische gegevens/GezinssituatieKind/OuderVerzorger/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>RelatedPerson</div>
@@ -23787,8 +22467,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23809,7 +22488,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23830,7 +22508,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23840,7 +22517,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10503</td>
             <td>
-               <div title="Kind/Demografische gegevens/GezinssituatieKind/BroerOfZus/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td>
                <div>RelatedPerson</div>
@@ -23850,8 +22527,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23872,7 +22548,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23889,7 +22564,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -23910,7 +22584,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24032,19 +22705,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1407</td>
             <td>
@@ -24059,8 +22719,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24081,8 +22739,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24103,8 +22759,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24125,8 +22779,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24147,8 +22799,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24169,8 +22819,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24191,8 +22839,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24213,7 +22859,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24234,7 +22879,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24255,7 +22899,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24276,7 +22919,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24297,7 +22939,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24318,7 +22959,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24339,7 +22979,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24360,7 +22999,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24381,7 +23019,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24402,8 +23039,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24427,8 +23062,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24452,8 +23085,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24474,7 +23105,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24495,8 +23125,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24517,7 +23145,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24538,7 +23165,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24559,7 +23185,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24580,7 +23205,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24601,7 +23225,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24622,7 +23245,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24643,8 +23265,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24665,7 +23285,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24686,8 +23305,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24708,7 +23325,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24729,7 +23345,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24750,7 +23365,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24771,7 +23385,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24792,7 +23405,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24813,7 +23425,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24834,8 +23445,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24856,7 +23465,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24877,8 +23485,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24899,7 +23505,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24920,7 +23525,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24941,7 +23545,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24962,7 +23565,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -24983,7 +23585,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25004,7 +23605,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25025,7 +23625,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25049,7 +23648,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25073,7 +23671,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25097,7 +23694,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25110,7 +23706,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3057</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Huid/Huid (Observatie)/AnatomischeLocatie">AnatomischeLocatie</div>
+               <div title="Bouwstenen/Subbouwstenen/AnatomischeLocatie">AnatomischeLocatie</div>
             </td>
             <td>
                <div>Observation.bodySite</div>
@@ -25121,7 +23717,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25145,7 +23740,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25169,7 +23763,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -25720,7 +24313,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2974</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax ">Thorax</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax">Thorax</div>
             </td>
             <td>
                <div>Observation</div>
@@ -25743,7 +24336,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2975</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Thorax (observatie)">Thorax (observatie)</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Thorax (observatie)">Thorax (observatie)</div>
             </td>
             <td>
                <div>Observation</div>
@@ -25766,7 +24359,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2978</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Thorax (observatie)/ThoraxDatumTijd">ThoraxDatumTijd</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Thorax (observatie)/ThoraxDatumTijd">ThoraxDatumTijd</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectiveDateTime</div>
@@ -25789,7 +24382,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2979</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Thorax (observatie)/ThoraxWaarde">ThoraxWaarde</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Thorax (observatie)/ThoraxWaarde">ThoraxWaarde</div>
             </td>
             <td>
                <div>Observation.value[x]:valueCodeableConcept</div>
@@ -25812,7 +24405,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2980</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Thorax (observatie)/ObservatieMethode">ObservatieMethode</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Thorax (observatie)/ObservatieMethode">ObservatieMethode</div>
             </td>
             <td>
                <div>Observation.method</div>
@@ -25835,7 +24428,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2981</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Thorax (observatie)/Toelichting">Toelichting</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Thorax (observatie)/Toelichting">Toelichting</div>
             </td>
             <td>
                <div>Observation.comment</div>
@@ -25858,7 +24451,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2995</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax">Probleem_Thorax</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax">Probleem_Thorax</div>
             </td>
             <td>
                <div>Condition</div>
@@ -25878,7 +24471,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2996</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/ProbleemAnatomischeLocatie">ProbleemAnatomischeLocatie</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/ProbleemAnatomischeLocatie">ProbleemAnatomischeLocatie</div>
             </td>
             <td>
                <div>Condition.bodySite</div>
@@ -25898,7 +24491,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2997</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/ProbleemLateraliteit">ProbleemLateraliteit</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/ProbleemLateraliteit">ProbleemLateraliteit</div>
             </td>
             <td>
                <div>Condition.bodySite.extension:Laterality.value[x]:valueCodeableConcept</div>
@@ -25918,7 +24511,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2998</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/ProbleemType">ProbleemType</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/ProbleemType">ProbleemType</div>
             </td>
             <td>
                <div>Condition.category</div>
@@ -25938,7 +24531,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2999</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/ProbleemNaam">ProbleemNaam</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/ProbleemNaam">ProbleemNaam</div>
             </td>
             <td>
                <div>Condition.code</div>
@@ -25958,7 +24551,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3000</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/ProbleemBeginDatum">ProbleemBeginDatum</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/ProbleemBeginDatum">ProbleemBeginDatum</div>
             </td>
             <td>
                <div>Condition.onset[x]:onsetDateTime</div>
@@ -25978,7 +24571,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3001</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/ProbleemEindDatum">ProbleemEindDatum</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/ProbleemEindDatum">ProbleemEindDatum</div>
             </td>
             <td>
                <div>Condition.abatement[x]:abatementDateTime</div>
@@ -25998,7 +24591,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3002</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/ProbleemStatus">ProbleemStatus</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/ProbleemStatus">ProbleemStatus</div>
             </td>
             <td>
                <div>Condition.clinicalStatus</div>
@@ -26018,7 +24611,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3003</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/VerificatieStatus">VerificatieStatus</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/VerificatieStatus">VerificatieStatus</div>
             </td>
             <td>
                <div>Condition.verificationStatus</div>
@@ -26038,7 +24631,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3004</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax /Probleem_Thorax/Toelichting">Toelichting</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Thorax/Probleem_Thorax/Toelichting">Toelichting</div>
             </td>
             <td>
                <div>Condition.note</div>
@@ -27083,7 +25676,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27107,7 +25699,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27131,7 +25722,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27155,7 +25745,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27168,7 +25757,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-4305</td>
             <td>
-               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Genitalia/Genitalia (observatie)/AnatomischeLocatie">AnatomischeLocatie</div>
+               <div title="Bouwstenen/Subbouwstenen/AnatomischeLocatie">AnatomischeLocatie</div>
             </td>
             <td>
                <div>Observation.bodySite</div>
@@ -27179,7 +25768,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27203,7 +25791,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27227,7 +25814,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27451,7 +26037,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27475,7 +26060,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27499,7 +26083,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27523,7 +26106,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27547,7 +26129,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27571,7 +26152,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27807,7 +26387,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10555</td>
             <td>
-               <div title="Kind/Betrokkenheid kinderarts/Specialist">Specialist</div>
+               <div title="Vrouw/Betrokken zorgverlener/ zorginstelling/Specialist">Specialist</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -27817,7 +26397,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -27967,7 +26547,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3097</td>
             <td>
-               <div title="Kind/Ondersteuning opvang/Verrichting (Ondersteuning opvang)/Indicatie/Probleem (2017)">Probleem</div>
+               <div title="Bouwstenen/Behandeling/Probleem (2017)">Probleem</div>
             </td>
             <td>
                <div>Condition</div>
@@ -28047,7 +26627,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10458</td>
             <td>
-               <div title="Kind/Ondersteuning opvang/Verrichting (Ondersteuning opvang)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -28057,7 +26637,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -28087,7 +26667,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10459</td>
             <td>
-               <div title="Kind/Ondersteuning opvang/Verrichting (Ondersteuning opvang)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -28097,7 +26677,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -28127,7 +26707,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10460</td>
             <td>
-               <div title="Kind/Ondersteuning opvang/Verrichting (Ondersteuning opvang)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -28137,7 +26717,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -28167,7 +26747,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10461</td>
             <td>
-               <div title="Kind/Ondersteuning opvang/Verrichting (Ondersteuning opvang)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -28177,34 +26757,11 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-1489</td>
-            <td>
-               <div title="Kind/Problematiek kind">Problematiek kind</div>
-            </td>
-            <td>
-               <div>Condition</div>
-            </td>
-            <td>
-               <div>bc-DisorderOfChild</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-DisorderOfChild</span> - path <span>Condition</span>
-                  </li>
-               </ul>
             </td>
          </tr>
          <tr class="row-valid">
@@ -28437,9 +26994,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-7899</td>
             <td>
@@ -28459,30 +27013,6 @@
             <td>
                <ul>
                   <li>Mapping <span>bc-DisorderOfChild</span> - path <span>Condition.extension:lineSepsis</span>
-                  </li>
-               </ul>
-            </td>
-         </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid">
-            <td>peri32-dataelement-1490</td>
-            <td>
-               <div title="Kind/Problematiek kind/Geboortetrauma">Geboortetrauma</div>
-            </td>
-            <td>
-               <div>Condition</div>
-            </td>
-            <td>
-               <div>bc-DisorderOfChild</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-DisorderOfChild</span> - path <span>Condition</span>
                   </li>
                </ul>
             </td>
@@ -28718,29 +27248,6 @@
             </td>
          </tr>
          <tr class="row-valid">
-            <td>peri32-dataelement-1513</td>
-            <td>
-               <div title="Kind/Problematiek kind/Congenitale aandoeningen">Congenitale aandoeningen</div>
-            </td>
-            <td>
-               <div>Condition</div>
-            </td>
-            <td>
-               <div>bc-DisorderOfChild</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <ul>
-                  <li>Mapping <span>bc-DisorderOfChild</span> - path <span>Condition</span>
-                  </li>
-               </ul>
-            </td>
-         </tr>
-         <tr class="row-valid">
             <td>peri32-dataelement-1514</td>
             <td>
                <div title="Kind/Problematiek kind/Congenitale aandoeningen/Probleem (Congenitale aandoeningen)">Probleem (Congenitale aandoeningen)</div>
@@ -28970,102 +27477,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-8756</td>
             <td>
@@ -29080,7 +27491,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29090,7 +27500,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8779</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Contact">Contact</div>
+               <div title="Administratief/Contact">Contact</div>
             </td>
             <td>
                <div>Encounter</div>
@@ -29100,8 +27510,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29111,7 +27520,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8758</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Lichaamsgewicht">Lichaamsgewicht</div>
+               <div title="Bouwstenen/Metingen/Lichaamsgewicht">Lichaamsgewicht</div>
             </td>
             <td>
                <div>Observation</div>
@@ -29121,8 +27530,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29132,7 +27540,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8759</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Schedelomvang">Schedelomvang</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Schedelomvang">Schedelomvang</div>
             </td>
             <td>
                <div>Observation</div>
@@ -29142,7 +27550,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29152,7 +27560,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10660</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Lichaamstemperatuur">Lichaamstemperatuur</div>
+               <div title="Bouwstenen/Metingen/Lichaamstemperatuur">Lichaamstemperatuur</div>
             </td>
             <td>
                <div>Observation</div>
@@ -29162,8 +27570,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29173,7 +27580,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8757</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/VoedingspatroonZuigeling">VoedingspatroonZuigeling</div>
+               <div title="Bouwstenen/Klinische context/VoedingspatroonZuigeling">VoedingspatroonZuigeling</div>
             </td>
             <td>
                <div>Observation</div>
@@ -29183,8 +27590,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29335,7 +27741,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8777</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Ondersteuning bij ontslag naar huis (Verrichting)/Indicatie/Probleem (ProblematiekKind)">Probleem (ProblematiekKind)</div>
+               <div title="Kind/Problematiek kind/Probleem (ProblematiekKind)">Probleem (ProblematiekKind)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -29345,7 +27751,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29358,7 +27764,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-8778</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Ondersteuning bij ontslag naar huis (Verrichting)/Indicatie/Probleem (Congenitale aandoeningen)">Probleem (Congenitale aandoeningen)</div>
+               <div title="Kind/Problematiek kind/Congenitale aandoeningen/Probleem (Congenitale aandoeningen)">Probleem (Congenitale aandoeningen)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -29368,7 +27774,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29450,7 +27856,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10470</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Ondersteuning bij ontslag naar huis (Verrichting)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -29460,7 +27866,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29493,7 +27899,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10471</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Ondersteuning bij ontslag naar huis (Verrichting)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -29503,7 +27909,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29536,7 +27942,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10472</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Ondersteuning bij ontslag naar huis (Verrichting)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -29546,7 +27952,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29576,7 +27982,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10473</td>
             <td>
-               <div title="Kind/Opname, Ontslag, Overplaatsing/Ondersteuning bij ontslag naar huis (Verrichting)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -29586,75 +27992,13 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1123</td>
             <td>
@@ -29669,9 +28013,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29704,7 +28045,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2416</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)">Verrichting (Onderzoek)</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)">Verrichting (Onderzoek)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -29715,8 +28056,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29726,7 +28065,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2417</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/VerrichtingStartDatum">VerrichtingStartDatum</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/VerrichtingStartDatum">VerrichtingStartDatum</div>
             </td>
             <td>
                <div>Procedure.effectivePeriod.start</div>
@@ -29737,8 +28076,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1  Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29748,7 +28085,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2418</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/VerrichtingEindDatum">VerrichtingEindDatum</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/VerrichtingEindDatum">VerrichtingEindDatum</div>
             </td>
             <td>
                <div>Procedure.effectivePeriod.end</div>
@@ -29759,7 +28096,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29769,7 +28105,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2419</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/VerrichtingAnatomischeLocatie">VerrichtingAnatomischeLocatie</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/VerrichtingAnatomischeLocatie">VerrichtingAnatomischeLocatie</div>
             </td>
             <td>
                <div>Procedure.bodySite</div>
@@ -29780,7 +28116,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29790,7 +28125,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2420</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/VerrichtingLateraliteit">VerrichtingLateraliteit</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/VerrichtingLateraliteit">VerrichtingLateraliteit</div>
             </td>
             <td>
                <div>Procedure.bodySite.extension:ProcedureLaterality.value[x]:valueCodeableConcept</div>
@@ -29801,7 +28136,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29811,7 +28145,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2421</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Indicatie">Indicatie</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/Indicatie">Indicatie</div>
             </td>
             <td>
                <div>Procedure.reasonReference</div>
@@ -29822,28 +28156,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-2422</td>
-            <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Indicatie/Probleem">Probleem</div>
-            </td>
-            <td>
-               <div>Condition</div>
-            </td>
-            <td>
-               <div>zib-Problem</div>
-            </td>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29853,7 +28165,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2423</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/VerrichtingType">VerrichtingType</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/VerrichtingType">VerrichtingType</div>
             </td>
             <td>
                <div>Procedure.code</div>
@@ -29864,8 +28176,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29878,7 +28188,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2424</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/VerrichtingMethode">VerrichtingMethode</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/VerrichtingMethode">VerrichtingMethode</div>
             </td>
             <td>
                <div>Procedure.extension:procedureMethod</div>
@@ -29889,7 +28199,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29902,7 +28211,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2425</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Procedure.focalDevice</div>
@@ -29913,7 +28222,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29926,7 +28234,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10474</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -29936,8 +28244,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29947,7 +28254,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2427</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Locatie">Locatie</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/Locatie">Locatie</div>
             </td>
             <td>
                <div>Procedure.location</div>
@@ -29958,8 +28265,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29972,7 +28277,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2433</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -29982,9 +28287,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -29994,7 +28297,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2429</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Uitvoerder">Uitvoerder</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/Uitvoerder">Uitvoerder</div>
             </td>
             <td>
                <div>Procedure.performer.actor</div>
@@ -30005,8 +28308,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30019,7 +28320,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2434</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -30029,9 +28330,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30041,7 +28340,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2431</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Aanvrager">Aanvrager</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)/Aanvrager">Aanvrager</div>
             </td>
             <td>
                <div>Procedure.Requestrequester</div>
@@ -30052,7 +28351,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30062,7 +28360,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2435</td>
             <td>
-               <div title="Medisch onderzoek/Verrichting (Onderzoek)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -30072,8 +28370,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30094,7 +28391,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30115,7 +28411,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30136,7 +28431,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30157,7 +28451,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30178,7 +28471,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30199,7 +28491,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30220,7 +28511,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30241,7 +28531,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30254,7 +28543,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10283</td>
             <td>
-               <div title="Medisch onderzoek/Foetusspecifieke onderzoeksgegevens/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Observation.subject</div>
@@ -30264,8 +28553,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30305,7 +28593,7 @@
          <tr class="row-valid">
             <td>peri31-dataelement-1483</td>
             <td>
-               <div title="Medisch onderzoek/Foetusspecifieke onderzoeksgegevens/Foetale monitoring (CTG)/Uterusactiviteit">Uterusactiviteit</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Uterusactiviteit">Uterusactiviteit</div>
             </td>
             <td>
                <div>Observation</div>
@@ -30315,7 +28603,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30351,7 +28639,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-11025</td>
             <td>
-               <div title="Medisch onderzoek/Foetusspecifieke onderzoeksgegevens/Foetale monitoring (CTG)/TijdsInterval">TijdsInterval</div>
+               <div title="Bouwstenen/Subbouwstenen/TijdsInterval">TijdsInterval</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectivePeriod</div>
@@ -30361,7 +28649,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30719,7 +29007,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3908</td>
             <td>
-               <div title="Medisch onderzoek/Foetusspecifieke onderzoeksgegevens/Foetale monitoring (CTG)/Beoordelaar/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -30729,7 +29017,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30750,7 +29038,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30774,7 +29061,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30798,7 +29084,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30822,7 +29107,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30846,7 +29130,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30870,7 +29153,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30894,7 +29176,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30918,7 +29199,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30942,7 +29222,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30966,7 +29245,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -30990,7 +29268,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31014,7 +29291,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31038,7 +29314,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31062,7 +29337,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31086,7 +29360,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31110,7 +29383,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31134,7 +29406,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31155,7 +29426,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31176,7 +29446,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31197,7 +29466,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31218,7 +29486,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -31239,7 +29506,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32295,7 +30561,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32319,7 +30584,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32343,7 +30607,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32367,7 +30630,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32391,7 +30653,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32415,7 +30676,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32439,7 +30699,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32463,7 +30722,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32487,7 +30745,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32511,7 +30768,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32535,7 +30791,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32559,7 +30814,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32583,7 +30837,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32607,7 +30860,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32631,7 +30883,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32655,7 +30906,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32679,7 +30929,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32703,7 +30952,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32727,7 +30975,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32797,7 +31044,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32821,7 +31067,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32831,12 +31076,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2437</td>
             <td>
@@ -32851,7 +31090,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32875,7 +31113,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32899,7 +31136,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32923,7 +31159,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32947,7 +31182,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32971,7 +31205,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -32995,7 +31228,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33019,7 +31251,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33043,7 +31274,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33067,7 +31297,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33091,7 +31320,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33115,7 +31343,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33139,7 +31366,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33163,7 +31389,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33187,7 +31412,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33211,7 +31435,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33235,7 +31458,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33259,7 +31481,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33283,7 +31504,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33307,7 +31527,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33331,7 +31550,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33355,7 +31573,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33379,7 +31596,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33403,7 +31619,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33427,7 +31642,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33451,7 +31665,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33475,7 +31688,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33499,7 +31711,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33523,7 +31734,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33547,7 +31757,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33571,7 +31780,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33595,7 +31803,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33619,7 +31826,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33643,7 +31849,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33667,7 +31872,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33691,7 +31895,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33715,7 +31918,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33739,7 +31941,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33763,7 +31964,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33787,7 +31987,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33811,7 +32010,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33835,7 +32033,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33859,7 +32056,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33883,7 +32079,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33907,7 +32102,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33931,7 +32125,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33955,7 +32148,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -33979,7 +32171,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34003,7 +32194,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34027,7 +32217,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34051,7 +32240,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34075,7 +32263,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34099,7 +32286,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34123,7 +32309,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34147,7 +32332,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34171,7 +32355,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34195,7 +32378,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34219,7 +32401,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34243,7 +32424,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34267,7 +32447,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34291,7 +32470,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34315,7 +32493,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34339,7 +32516,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34363,7 +32539,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34387,7 +32562,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34411,7 +32585,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34421,96 +32594,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-7847</td>
             <td>
@@ -34525,7 +32608,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34549,7 +32631,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34573,7 +32654,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34597,7 +32677,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34621,7 +32700,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34645,7 +32723,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34669,7 +32746,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34690,7 +32766,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34711,7 +32786,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34724,7 +32798,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-7875</td>
             <td>
-               <div title="Medisch onderzoek/Foetusspecifieke onderzoeksgegevens/Echoscopie/TekstUitslag/Verrichting/Verrichting (Onderzoek)">Verrichting (Onderzoek)</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Verrichting (Maternaal onderzoek)">Verrichting (Onderzoek)</div>
             </td>
             <td>
                <div>Procedure</div>
@@ -34734,8 +32808,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34759,7 +32832,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34780,7 +32852,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34801,7 +32872,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -34811,7 +32881,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9885</td>
             <td>
-               <div title="Medisch onderzoek/Foetusspecifieke onderzoeksgegevens/Echoscopie/Media">Media</div>
+               <div title="Medisch onderzoek/Media">Media</div>
             </td>
             <td>
                <div>Binary</div>
@@ -34822,7 +32892,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Echo integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -35018,7 +33087,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10949</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/NIPT/LaboratoriumUitslag/Autorisator onderzoek/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -35028,7 +33097,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -35049,8 +33118,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36063,7 +34130,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36087,7 +34153,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36100,7 +34165,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3894</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Uterusactiviteit/Periode/TijdsInterval">TijdsInterval</div>
+               <div title="Bouwstenen/Subbouwstenen/TijdsInterval">TijdsInterval</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectivePeriod</div>
@@ -36110,8 +34175,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36135,7 +34199,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36159,7 +34222,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36183,7 +34245,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36193,7 +34254,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-3904</td>
             <td>
@@ -36208,7 +34268,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36232,7 +34291,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36256,7 +34314,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36280,7 +34337,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36293,7 +34349,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3895</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Uterusactiviteit/Beoordelaar/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -36303,16 +34359,13 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1125</td>
             <td>
@@ -36327,7 +34380,6 @@
             <td>
                <ul>
                   <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36348,7 +34400,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36369,7 +34420,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36390,7 +34440,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36411,7 +34460,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36432,7 +34480,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36453,7 +34500,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36474,7 +34520,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36495,7 +34540,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36516,7 +34560,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36537,7 +34580,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36558,7 +34600,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36579,7 +34620,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36600,7 +34640,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36621,7 +34660,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36642,7 +34680,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36663,7 +34700,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36684,7 +34720,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36705,7 +34740,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36726,7 +34760,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36747,7 +34780,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36768,7 +34800,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36789,7 +34820,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36810,7 +34840,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36831,7 +34860,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36852,7 +34880,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36873,7 +34900,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36894,7 +34920,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36915,7 +34940,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36936,7 +34960,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36957,7 +34980,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36978,7 +35000,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -36999,7 +35020,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37020,7 +35040,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37041,7 +35060,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37062,7 +35080,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37083,7 +35100,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37104,7 +35120,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37125,7 +35140,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37146,7 +35160,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37167,7 +35180,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37188,7 +35200,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37209,7 +35220,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37230,7 +35240,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37251,7 +35260,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37272,7 +35280,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37293,7 +35300,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37314,7 +35320,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37335,7 +35340,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37356,7 +35360,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37377,7 +35380,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37398,7 +35400,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37419,7 +35420,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37440,7 +35440,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37601,7 +35600,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37622,7 +35620,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37643,7 +35640,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37664,7 +35660,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37685,7 +35680,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37706,7 +35700,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37727,7 +35720,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37748,7 +35740,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -37958,7 +35949,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3787</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment ">Urinesediment</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment">Urinesediment</div>
             </td>
             <td>
                <div>Observation</div>
@@ -37978,7 +35969,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3775</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Ketonen (Meting)">Ketonen (Meting)</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Ketonen (Meting)">Ketonen (Meting)</div>
             </td>
             <td>
                <div>Observation</div>
@@ -37998,7 +35989,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3777</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Ketonen (Meting)/KetonenWaarde">KetonenWaarde</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Ketonen (Meting)/KetonenWaarde">KetonenWaarde</div>
             </td>
             <td>
                <div>Observation.value</div>
@@ -38018,7 +36009,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3778</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Ketonen (Meting)/MeetMethode">MeetMethode</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Ketonen (Meting)/MeetMethode">MeetMethode</div>
             </td>
             <td>
                <div>Observation.method</div>
@@ -38038,7 +36029,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3781</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Ketonen (Meting)/KetonenDatumBeginTijd">KetonenDatumBeginTijd</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Ketonen (Meting)/KetonenDatumBeginTijd">KetonenDatumBeginTijd</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectivePeriod.start</div>
@@ -38058,7 +36049,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3782</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Ketonen (Meting)/KetonenDatumEindTijd">KetonenDatumEindTijd</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Ketonen (Meting)/KetonenDatumEindTijd">KetonenDatumEindTijd</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectivePeriod.end</div>
@@ -38078,7 +36069,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3783</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Ketonen (Meting)/Toelichting">Toelichting</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Ketonen (Meting)/Toelichting">Toelichting</div>
             </td>
             <td>
                <div>Observation.comment</div>
@@ -38098,7 +36089,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3788</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Nitriet (Meting)">Nitriet (Meting)</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Nitriet (Meting)">Nitriet (Meting)</div>
             </td>
             <td>
                <div>Observation</div>
@@ -38118,7 +36109,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3790</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Nitriet (Meting)/NitrietWaarde">NitrietWaarde</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Nitriet (Meting)/NitrietWaarde">NitrietWaarde</div>
             </td>
             <td>
                <div>Observation.value</div>
@@ -38138,7 +36129,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3791</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Nitriet (Meting)/MeetMethode">MeetMethode</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Nitriet (Meting)/MeetMethode">MeetMethode</div>
             </td>
             <td>
                <div>Observation.method</div>
@@ -38158,7 +36149,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3794</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Nitriet (Meting)/NitrietDatumBeginTijd">NitrietDatumBeginTijd</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Nitriet (Meting)/NitrietDatumBeginTijd">NitrietDatumBeginTijd</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectivePeriod.start</div>
@@ -38178,7 +36169,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3795</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Nitriet (Meting)/NitrietDatumEindTijd">NitrietDatumEindTijd</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Nitriet (Meting)/NitrietDatumEindTijd">NitrietDatumEindTijd</div>
             </td>
             <td>
                <div>Observation.effective[x]:effectivePeriod.end</div>
@@ -38198,7 +36189,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3796</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /Nitriet (Meting)/Toelichting">Toelichting</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/Nitriet (Meting)/Toelichting">Toelichting</div>
             </td>
             <td>
                <div>Observation.comment</div>
@@ -38218,7 +36209,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3800</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /LaboratoriumTest_ProteineUrine">LaboratoriumTest_ProteineUrine</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/LaboratoriumTest_ProteineUrine">LaboratoriumTest_ProteineUrine</div>
             </td>
             <td>
                <div>Observation</div>
@@ -38238,7 +36229,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3801</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /LaboratoriumTest_ProteineUrine/TestCode">TestCode</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/LaboratoriumTest_ProteineUrine/TestCode">TestCode</div>
             </td>
             <td>
                <div>Observation.code</div>
@@ -38258,7 +36249,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-3804</td>
             <td>
-               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment /LaboratoriumTest_ProteineUrine/TestUitslag">TestUitslag</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/Urine/Urinesediment/LaboratoriumTest_ProteineUrine/TestUitslag">TestUitslag</div>
             </td>
             <td>
                <div>Observation.value</div>
@@ -38729,7 +36720,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38750,7 +36740,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38774,7 +36763,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38798,7 +36786,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38822,7 +36809,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38846,7 +36832,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38870,7 +36855,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38894,7 +36878,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38918,7 +36901,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38942,7 +36924,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38966,7 +36947,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -38990,7 +36970,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39123,7 +37102,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10800</td>
             <td>
-               <div title="Postnatale fase/Moeder/Verrichting (Postpartum complicatie)/Indicatie/Probleem (Postpartum complicatie)">Probleem (Postpartum complicatie)</div>
+               <div title="Postnatale fase/Moeder/Probleem (Postpartum complicatie)">Probleem (Postpartum complicatie)</div>
             </td>
             <td>
                <div>Condition</div>
@@ -39133,7 +37112,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39206,7 +37185,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10475</td>
             <td>
-               <div title="Postnatale fase/Moeder/Verrichting (Postpartum complicatie)/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -39216,7 +37195,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39246,7 +37225,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10476</td>
             <td>
-               <div title="Postnatale fase/Moeder/Verrichting (Postpartum complicatie)/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td>
                <div>Organization</div>
@@ -39256,7 +37235,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39286,7 +37265,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10477</td>
             <td>
-               <div title="Postnatale fase/Moeder/Verrichting (Postpartum complicatie)/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -39296,7 +37275,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39326,7 +37305,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10478</td>
             <td>
-               <div title="Postnatale fase/Moeder/Verrichting (Postpartum complicatie)/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>Practitioner</div>
@@ -39336,7 +37315,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39357,7 +37336,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39381,7 +37359,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39405,7 +37382,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39429,7 +37405,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39453,7 +37428,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39477,7 +37451,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39524,7 +37497,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39548,7 +37520,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39561,7 +37532,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10729</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Vrouw/Controles moeder/Contact">Contact</div>
+               <div title="Administratief/Contact">Contact</div>
             </td>
             <td>
                <div>Encounter</div>
@@ -39571,8 +37542,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39585,7 +37555,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2798</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Vrouw/Controles moeder/Lichaamstemperatuur">Lichaamstemperatuur</div>
+               <div title="Bouwstenen/Metingen/Lichaamstemperatuur">Lichaamstemperatuur</div>
             </td>
             <td>
                <div>Observation.value[x]:valueQuantity</div>
@@ -39595,8 +37565,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39617,7 +37586,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39638,7 +37606,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39659,7 +37626,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39680,7 +37646,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39701,7 +37666,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39722,7 +37686,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39743,7 +37706,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39767,15 +37729,12 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2762</td>
             <td>
@@ -39790,7 +37749,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39800,7 +37758,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10523</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Vrouw/Controles moeder/Blaasfunctie/UrineKatheter/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -39810,16 +37768,13 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2780</td>
             <td>
@@ -39834,7 +37789,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39855,7 +37809,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39876,7 +37829,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39900,15 +37852,12 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2785</td>
             <td>
@@ -39923,7 +37872,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39944,7 +37892,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39965,7 +37912,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -39995,7 +37941,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10527</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Vrouw/Controles moeder/Darmfunctie/Incontinentiemateriaal/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td>
                <div>Device</div>
@@ -40005,7 +37951,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40026,7 +37972,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40036,7 +37981,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2791</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Vrouw/Controles moeder/Bloeddruk">Bloeddruk</div>
+               <div title="Bouwstenen/Metingen/Bloeddruk">Bloeddruk</div>
             </td>
             <td>
                <div>Observation</div>
@@ -40046,8 +37991,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40068,7 +38012,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40092,7 +38035,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40116,7 +38058,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40140,7 +38081,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40164,7 +38104,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40188,7 +38127,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40212,7 +38150,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40236,7 +38173,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40260,7 +38196,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40284,7 +38219,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40308,7 +38242,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40332,7 +38265,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40356,7 +38288,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40380,7 +38311,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40390,9 +38320,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-3129</td>
             <td>
@@ -40456,9 +38383,6 @@
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-3150</td>
             <td>
@@ -40473,7 +38397,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40483,7 +38406,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9860</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Vrouw/Controles moeder/Fundusstand (Meting)">Fundusstand (Meting)</div>
+               <div title="Zwangerschapsgegevens/Prenatale controle/Uitwendig onderzoek/Bevindingen Moeder/Fundusstand (Meting)">Fundusstand (Meting)</div>
             </td>
             <td>
                <div>Observation</div>
@@ -40493,8 +38416,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40518,7 +38440,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40542,7 +38463,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40566,7 +38486,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40820,7 +38739,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40844,7 +38762,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40868,7 +38785,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40892,7 +38808,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40939,7 +38854,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -40963,7 +38877,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41033,7 +38946,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41057,7 +38969,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41081,7 +38992,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41105,7 +39015,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41129,7 +39038,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41153,7 +39061,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41177,7 +39084,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41201,7 +39107,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41225,7 +39130,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41249,7 +39153,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41273,7 +39176,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41297,7 +39199,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41321,7 +39222,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41345,7 +39245,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41369,7 +39268,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41393,7 +39291,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41417,7 +39314,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41441,7 +39337,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41465,7 +39360,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41489,7 +39383,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41513,7 +39406,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41560,7 +39452,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41584,7 +39475,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41608,7 +39498,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41632,7 +39521,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41656,7 +39544,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41680,7 +39567,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41704,7 +39590,6 @@
             <td>
                <ul>
                   <li>0..1 C Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41714,9 +39599,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2880</td>
             <td>
@@ -41760,10 +39642,6 @@
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-2901</td>
             <td>
@@ -41778,7 +39656,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41799,7 +39676,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41812,7 +39688,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10798</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Vrouw/Controles moeder/Betrokkenheid andere zorgverlener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>PractitionerRole</div>
@@ -41822,8 +39698,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41844,7 +39719,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41857,7 +39731,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10663</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Patient">Patient</div>
+               <div title="Administratief/Patient">Patient</div>
             </td>
             <td>
                <div>Patient</div>
@@ -41867,8 +39741,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41892,7 +39765,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41905,7 +39777,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10730</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Controles kind/Contact">Contact</div>
+               <div title="Administratief/Contact">Contact</div>
             </td>
             <td>
                <div>Encounter</div>
@@ -41915,8 +39787,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41929,7 +39800,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2792</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Controles kind/Lichaamsgewicht">Lichaamsgewicht</div>
+               <div title="Bouwstenen/Metingen/Lichaamsgewicht">Lichaamsgewicht</div>
             </td>
             <td>
                <div>Observation</div>
@@ -41939,8 +39810,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41950,7 +39820,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2799</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Controles kind/Lichaamstemperatuur">Lichaamstemperatuur</div>
+               <div title="Bouwstenen/Metingen/Lichaamstemperatuur">Lichaamstemperatuur</div>
             </td>
             <td>
                <div>Observation</div>
@@ -41960,8 +39830,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -41971,7 +39840,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-7947</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Controles kind/VoedingspatroonZuigeling">VoedingspatroonZuigeling</div>
+               <div title="Bouwstenen/Klinische context/VoedingspatroonZuigeling">VoedingspatroonZuigeling</div>
             </td>
             <td>
                <div>Observation</div>
@@ -41982,7 +39851,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42006,7 +39874,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42030,7 +39897,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42054,7 +39920,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42078,7 +39943,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42102,7 +39966,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42126,7 +39989,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42150,7 +40012,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42174,7 +40035,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42198,7 +40058,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42222,7 +40081,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42246,7 +40104,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42270,7 +40127,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42294,7 +40150,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42318,7 +40173,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42342,7 +40196,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42366,7 +40219,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42390,7 +40242,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42414,7 +40265,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42438,7 +40288,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42462,7 +40311,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42486,7 +40334,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42512,7 +40359,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42536,7 +40382,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42560,7 +40405,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42584,7 +40428,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42608,7 +40451,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42632,7 +40474,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42656,7 +40497,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42680,7 +40520,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42704,7 +40543,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42728,7 +40566,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42752,7 +40589,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42776,7 +40612,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42800,7 +40635,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42824,7 +40658,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42848,7 +40681,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42861,7 +40693,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-9959</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Controles kind/Controle huid/Huid (Observatie)">Huid (Observatie)</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Huid/Huid (Observatie)">Huid (Observatie)</div>
             </td>
             <td>
                <div>Observation</div>
@@ -42871,8 +40703,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42896,7 +40727,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42917,7 +40747,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42938,7 +40767,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42959,7 +40787,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -42980,7 +40807,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43001,7 +40827,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43022,7 +40847,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43043,7 +40867,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43064,7 +40887,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43085,7 +40907,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43106,7 +40927,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43130,7 +40950,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43154,7 +40973,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43178,7 +40996,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43202,7 +41019,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43226,7 +41042,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 C Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43250,7 +41065,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43274,7 +41088,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43298,7 +41111,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43322,7 +41134,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43346,7 +41157,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43359,7 +41169,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10728</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Controles kind/Tonus/Neurologie (Observatie)">Neurologie (Observatie)</div>
+               <div title="Kind/Lichamelijk onderzoek kind/Bevindingen/Neurologie/Neurologie (Observatie)">Neurologie (Observatie)</div>
             </td>
             <td>
                <div>Observation</div>
@@ -43370,7 +41180,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43394,7 +41203,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43407,7 +41215,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10794</td>
             <td>
-               <div title="Postnatale fase/Kraamweek/Kind/Controles kind/Betrokkenheid andere zorgverlener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td>
                <div>PractitionerRole</div>
@@ -43417,8 +41225,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43439,7 +41246,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43463,7 +41269,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43487,7 +41292,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43511,7 +41315,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43535,7 +41338,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43559,7 +41361,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43583,7 +41384,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43607,7 +41407,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43631,7 +41430,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43655,7 +41453,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43679,7 +41476,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43703,7 +41499,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43727,7 +41522,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43751,7 +41545,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43775,7 +41568,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43799,7 +41591,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43823,7 +41614,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43847,7 +41637,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43871,7 +41660,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43895,7 +41683,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43919,7 +41706,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43943,7 +41729,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43967,7 +41752,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -43991,7 +41775,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44015,7 +41798,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44039,7 +41821,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44063,7 +41844,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44087,7 +41867,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44111,7 +41890,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44135,7 +41913,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44171,7 +41948,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-4324</td>
             <td>
-               <div title="Postnatale fase/Nacontrole/Contact">Contact</div>
+               <div title="Administratief/Contact">Contact</div>
             </td>
             <td>
                <div>Encounter</div>
@@ -44181,7 +41958,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44582,7 +42359,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-4333</td>
             <td>
@@ -44862,7 +42638,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-4326</td>
             <td>
-               <div title="Postnatale fase/Nacontrole/Bloeddruk">Bloeddruk</div>
+               <div title="Bouwstenen/Metingen/Bloeddruk">Bloeddruk</div>
             </td>
             <td>
                <div>Observation</div>
@@ -44872,7 +42648,7 @@
             </td>
             <td>
                <ul>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44882,7 +42658,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10676</td>
             <td>
-               <div title="Postnatale fase/Nacontrole/Lichaamsgewicht">Lichaamsgewicht</div>
+               <div title="Bouwstenen/Metingen/Lichaamsgewicht">Lichaamsgewicht</div>
             </td>
             <td/>
             <td>
@@ -44890,7 +42666,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44900,7 +42676,7 @@
          <tr class="row-valid">
             <td>peri32-dataelement-4328</td>
             <td>
-               <div title="Postnatale fase/Nacontrole/LaboratoriumTest_Hb">LaboratoriumTest_Hb</div>
+               <div title="Medisch onderzoek/Maternale onderzoeksgegevens/Urine-, bloed- en aanvullende onderzoeken/LaboratoriumTest_Hb">LaboratoriumTest_Hb</div>
             </td>
             <td>
                <div>Observation</div>
@@ -44910,7 +42686,7 @@
             </td>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -44927,37 +42703,12 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1528</td>
             <td>
@@ -45073,13 +42824,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1535</td>
             <td>
-               <div title="Bouwstenen/Behandeling/Verrichting/Indicatie/Probleem (2017)">Probleem</div>
+               <div title="Bouwstenen/Behandeling/Probleem (2017)">Probleem</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45137,13 +42888,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1539</td>
             <td>
-               <div title="Bouwstenen/Behandeling/Verrichting/MedischHulpmiddel/MedischHulpmiddel">MedischHulpmiddel</div>
+               <div title="Bouwstenen/Klinische context/MedischHulpmiddel">MedischHulpmiddel</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45169,13 +42920,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1541</td>
             <td>
-               <div title="Bouwstenen/Behandeling/Verrichting/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45201,13 +42952,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1543</td>
             <td>
-               <div title="Bouwstenen/Behandeling/Verrichting/Uitvoerder/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45233,13 +42984,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-1545</td>
             <td>
-               <div title="Bouwstenen/Behandeling/Verrichting/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45256,7 +43007,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45273,7 +43023,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45290,7 +43039,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45307,7 +43055,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45324,7 +43071,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45341,7 +43087,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45358,7 +43103,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45375,7 +43119,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45392,24 +43135,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-10381</td>
-            <td>
-               <div title="Bouwstenen/Klinische context/MedischHulpmiddel/Indicatie/Probleem">Probleem</div>
-            </td>
-            <td/>
-            <td/>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45426,7 +43151,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45443,7 +43167,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45460,7 +43183,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45477,7 +43199,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45487,14 +43208,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10526</td>
             <td>
-               <div title="Bouwstenen/Klinische context/MedischHulpmiddel/Locatie/Zorgaanbieder">Zorgaanbieder</div>
+               <div title="Administratief/Zorgaanbieder">Zorgaanbieder</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45511,7 +43231,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45521,14 +43240,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10525</td>
             <td>
-               <div title="Bouwstenen/Klinische context/MedischHulpmiddel/Zorgverlener/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45549,7 +43267,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45573,7 +43290,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45597,7 +43313,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45621,7 +43336,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45645,7 +43359,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45669,7 +43382,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45693,7 +43405,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45703,7 +43414,6 @@
                </ul>
             </td>
          </tr>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-7944</td>
             <td>
@@ -45718,7 +43428,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45742,7 +43451,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45766,7 +43474,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45790,7 +43497,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45814,7 +43520,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45834,29 +43539,12 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-3054</td>
             <td>
@@ -45867,7 +43555,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45884,7 +43571,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -45901,68 +43587,12 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri32-dataelement-1333</td>
             <td>
@@ -46037,8 +43667,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46057,8 +43685,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46075,8 +43701,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46093,8 +43717,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46111,8 +43733,6 @@
             <td>
                <ul>
                   <li>0..1  Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46129,8 +43749,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46147,8 +43765,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46165,8 +43781,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46183,8 +43797,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46201,8 +43813,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46219,8 +43829,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46237,8 +43845,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46255,7 +43861,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46272,7 +43877,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46289,7 +43893,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46306,7 +43909,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46323,7 +43925,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46340,7 +43941,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46357,7 +43957,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46374,7 +43973,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46391,7 +43989,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46408,7 +44005,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46425,7 +44021,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46442,7 +44037,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46459,7 +44053,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46476,7 +44069,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46493,7 +44085,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46510,7 +44101,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46527,7 +44117,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46544,7 +44133,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46561,7 +44149,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46578,7 +44165,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46595,7 +44181,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46612,7 +44197,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46629,7 +44213,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46646,7 +44229,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46663,7 +44245,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46680,7 +44261,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46697,7 +44277,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46714,7 +44293,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46731,7 +44309,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46748,7 +44325,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46765,7 +44341,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46782,7 +44357,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46799,24 +44373,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
-               </ul>
-            </td>
-            <td>
-               <span style="font-style: italic;">No mappings</span>
-            </td>
-         </tr>
-         <tr class="row-valid">
-            <td>peri32-dataelement-2681</td>
-            <td>
-               <div title="Bouwstenen/Metingen/LaboratoriumUitslag/GerelateerdeUitslag/LaboratoriumUitslag">LaboratoriumUitslag</div>
-            </td>
-            <td/>
-            <td/>
-            <td>
-               <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46833,7 +44389,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46843,14 +44398,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-2683</td>
             <td>
-               <div title="Bouwstenen/Metingen/LaboratoriumUitslag/Aanvrager/Zorgverlener">Zorgverlener</div>
+               <div title="Administratief/Zorgverlener">Zorgverlener</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46869,8 +44423,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46889,8 +44441,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46907,8 +44457,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46925,8 +44473,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -46943,8 +44489,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij 0.1 Beschikbaarstellen integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47047,7 +44591,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47066,7 +44609,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47083,7 +44625,6 @@
             <td>
                <ul>
                   <li>1..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47100,7 +44641,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47117,7 +44657,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47134,7 +44673,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47151,7 +44689,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47168,7 +44705,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47185,7 +44721,6 @@
             <td>
                <ul>
                   <li>0..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47202,7 +44737,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>1..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47219,7 +44753,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47236,7 +44769,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47253,7 +44785,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47270,7 +44801,6 @@
             <td>
                <ul>
                   <li>0..1 R Transaction MedMij Kraam integrale zwangerschapskaart</li>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47344,13 +44874,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10427</td>
             <td>
-               <div title="Bouwstenen/Patienten context/Wilsverklaring/Aandoening/Probleem (2020)">Probleem</div>
+               <div title="Bouwstenen/Behandeling/Probleem (2020)">Probleem</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>0..* R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47376,13 +44906,13 @@
          <tr class="row-valid">
             <td>peri32-dataelement-10429</td>
             <td>
-               <div title="Bouwstenen/Patienten context/Wilsverklaring/Vertegenwoordiger/Contactpersoon">Contactpersoon</div>
+               <div title="Administratief/Contactpersoon">Contactpersoon</div>
             </td>
             <td/>
             <td/>
             <td>
                <ul>
-                  <li>0..1 R Transaction MedMij Uitbreiding Verloskunde Integrale zwangerschapskaart</li>
+                  <li>1..* R Transaction MedMij Kraam integrale zwangerschapskaart</li>
                </ul>
             </td>
             <td>
@@ -47421,702 +44951,6 @@
                <span style="font-style: italic;">No mappings</span>
             </td>
          </tr>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
-         <tr class="row-valid"/>
          <tr class="row-valid">
             <td>peri31-dataelement-1429</td>
             <td>

--- a/wikigen/scripts/fhirmapping-report.sh
+++ b/wikigen/scripts/fhirmapping-report.sh
@@ -1,0 +1,2 @@
+current=`dirname $0`
+java -jar "$current/../../../YATC-tools/saxon/saxon.jar" -xsl:"$current/fhirmapping-report.xsl" "$current/../../fhirmapping-3-2.xml" outputdir=$current

--- a/wikigen/xsl/fhirmapping-report.cmd
+++ b/wikigen/xsl/fhirmapping-report.cmd
@@ -1,1 +1,0 @@
-java -jar ../../../YATC-tools/saxon/saxon.jar -xsl:fhirmapping_2_valueset.xsl ../../fhirmapping-3-2.xml

--- a/wikigen/xsl/fhirmapping-report.sh
+++ b/wikigen/xsl/fhirmapping-report.sh
@@ -1,1 +1,0 @@
-java -jar ../../../YATC-tools/saxon/saxon.jar -xsl:fhirmapping_2_valueset.xsl ../../fhirmapping-3-2.xml


### PR DESCRIPTION
wikigen/scripts now has some qa-ing on profiles and value sets. For profiles it generates a report with manual action. For value sets you may now generate those off the fhirmapping and the ada release file

I have a moved some profile mappings to top level because they are group concepts and their value should (and is) on the Observation.value.

I have removed the maternal death concepts from the bc-MaternalObservation, bc-PerinatalDeath because they are simply mapped onto the Patient. 

I have removed mappings for a couple of grouper concepts, that only group other grouper concepts.