### PR TITLE
NICTIZ-35369 added two codes to ValueSet bc-MaternalObservation-code

### DIFF
--- a/fhirmapping-3-2.xml
+++ b/fhirmapping-3-2.xml
@@ -5682,7 +5682,7 @@
 	<record>
 		<ID>peri32-dataelement-2279</ID>
 		<naam>Voorgenomen voeding (Observatie)</naam>
-		<mapping>Observation.value[x]:valueCodeableConcept</mapping>
+		<mapping>Observation</mapping>
 		<profile>bc-MaternalObservation</profile>
 		<in>false</in>
 	</record>

--- a/profiles/ValueSets/bc-BirthObservation-code.xml
+++ b/profiles/ValueSets/bc-BirthObservation-code.xml
@@ -18,13 +18,6 @@
          <system value="http://snomed.info/sct"/>
          <concept>
             <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
-               <valueString value="peri32-dataelement-4196 WerkelijkePlaatsBaringWaarde"/>
-            </extension>
-            <code value="366344009"/>
-            <display value="bevinding betreffende locatie van partus"/>
-         </concept>
-         <concept>
-            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
                <valueString value="peri32-dataelement-4135 ActiefMeepersenWaarde"/>
             </extension>
             <code value="249163006"/>
@@ -43,6 +36,13 @@
             </extension>
             <code value="364336006"/>
             <display value="soort partus (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-4196 WerkelijkePlaatsBaringWaarde"/>
+            </extension>
+            <code value="366344009"/>
+            <display value="bevinding betreffende locatie van partus"/>
          </concept>
       </include>
       <include>

--- a/profiles/ValueSets/bc-MaternalObservation-code.xml
+++ b/profiles/ValueSets/bc-MaternalObservation-code.xml
@@ -74,6 +74,13 @@
          </concept>
          <concept>
             <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
+               <valueString value="peri32-dataelement-2281 VoorgenomenVoedingWaarde"/>
+            </extension>
+            <code value="268467002"/>
+            <display value="voorgenomen voeding van zuigeling (bevinding)"/>
+         </concept>
+         <concept>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/Comment">
                <valueString value="peri32-dataelement-2275 VoorgenomenAchternaamWaarde"/>
             </extension>
             <code value="142981000146105"/>
@@ -295,6 +302,10 @@
             </extension>
             <code value="364297003"/>
             <display value="observatie betreffende perineum van vrouw (waarneembare entiteit)"/>
+         </concept>
+         <concept>
+            <code value="364554009"/>
+            <display value="Wound observable (observable entity)"/>
          </concept>
       </include>
       <include>

--- a/profiles/bc-MaternalObservation.xml
+++ b/profiles/bc-MaternalObservation.xml
@@ -281,6 +281,11 @@
         <map value="peri32-dataelement-2269" />
         <comment value="Kraamzorg aangevraagd (Observatie)" />
       </mapping>
+      <mapping>
+        <identity value="gebz-peri-v3.2" />
+        <map value="peri32-dataelement-2279" />
+        <comment value="Voorgenomen voeding (Observatie)" />
+      </mapping>
     </element>
     <element id="Observation.code">
       <path value="Observation.code" />
@@ -814,11 +819,6 @@
         <identity value="gebz-peri-v3.2" />
         <map value="peri32-dataelement-3337" />
         <comment value="VoorgenomenEchelonWaarde" />
-      </mapping>
-      <mapping>
-        <identity value="gebz-peri-v3.2" />
-        <map value="peri32-dataelement-2279" />
-        <comment value="Voorgenomen voeding (Observatie)" />
       </mapping>
       <mapping>
         <identity value="gebz-peri-v3.2" />

--- a/wikigen/scripts/fhirmapping-2-valueset.cmd
+++ b/wikigen/scripts/fhirmapping-2-valueset.cmd
@@ -1,3 +1,3 @@
-java -jar "%~dp0../../../YATC-tools/saxon/saxon.jar" -xsl:"%~dp0fhirmapping-2-valueset.xsl" "%~dp0../../fhirmapping-3-2.xml" outputdir=%~dp0
-
+java -jar "%~dp0../../../YATC-tools/saxon/saxon.jar" -xsl:"%~dp0fhirmapping-2-valueset.xsl" "%~dp0../../fhirmapping-3-2.xml" outputdir=%~dp0 
+pause
 

--- a/wikigen/scripts/fhirmapping-2-valueset.xsl
+++ b/wikigen/scripts/fhirmapping-2-valueset.xsl
@@ -179,7 +179,8 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 
                 <!-- Start building the ValueSet -->
                 <xsl:message>Creating <xsl:value-of select="$outputdir"/>/ValueSets/<xsl:value-of select="current-grouping-key()"/>-code.xml ...</xsl:message>
-                <xsl:result-document href="{$outputdir}/ValueSets/{current-grouping-key()}-code.xml" indent="yes" omit-xml-declaration="yes">
+                <xsl:result-document href="file:///{$outputdir}/ValueSets/{current-grouping-key()}-code.xml" indent="yes" omit-xml-declaration="yes">
+                    <xsl:variable name="myVar" select="concat(current-grouping-key(), '-code')"/>
                     <ValueSet xmlns="http://hl7.org/fhir">
                         <id value="{current-grouping-key()}-code"/>
                         <meta>
@@ -214,6 +215,16 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                                             <display value="{current-group()[1]/@displayName}"/>
                                         </concept>
                                     </xsl:for-each-group>
+                                    
+                                    <!--Add a hard-coded concept code in ValueSet bc-MaternalObservation-code.xml, for the include subsection with Snomed codes-->
+                                    <!--Needed because the code is a Fixed Code on element Observation.code.coding:WoundObservableCode.code in the zib profile of WoundCharacteristics but is not included in the fhirmapping input file-->
+                                    <!--see http://nictiz.nl/fhir/StructureDefinition/WoundCharacteristics and ticket NICTIZ-35369-->
+                                    <xsl:if test="contains(local:getUri(current-grouping-key()),'snomed') and ($myVar = 'bc-MaternalObservation-code')">
+                                        <concept>
+                                            <code value="364554009"/>
+                                            <display value="Wound observable (observable entity)"/>
+                                        </concept>
+                                    </xsl:if>      
                                 </include>
                             </xsl:for-each-group>
                             <!-- Create compose.include elements per valueSet preventing duplicates ... technically they could be in a single include but left it the way I found it -->


### PR DESCRIPTION
- Changed mapping of dataelement-2279 in fhirmapping so that it would be automatically added to bc-MaternalObservation-code
- Changed mapping in corresponding profile bc-MaternalObservation
- Changes in stylesheet fhirmapping-2-valueset.xsl so that code 364554009 is always added to bc-MaternalObservation-code, regardless of presence in fhirmapping
- Small change in fhirmapping-2-valueset.cmd for user interface
- Generated ValueSets with fhirmapping-2-valueset.xsl and commited changes in the profiles>ValueSets folder